### PR TITLE
fixing tech installation on windows

### DIFF
--- a/install_tech.py
+++ b/install_tech.py
@@ -27,7 +27,7 @@ def make_link(src, dest, overwrite: bool = True) -> None:
     try:
         os.symlink(src, dest, target_is_directory=True)
     except OSError:
-        shutil.copy(src, dest)
+        shutil.copytree(src, dest)
     print("link made:")
     print(f"From: {src}")
     print(f"To:   {dest}")


### PR DESCRIPTION
On Windows, we cannot create symlinks without admin privileges by default. So, this case is currently handled by copying the klayout folder (instead of creating a symlink), but it uses `shutil.copy`, which is invalid for copying directories. This PR changes to use `copytree` instead.