### PR TITLE
update gdsfactory 8.15.0

### DIFF
--- a/cspdk/si220/__init__.py
+++ b/cspdk/si220/__init__.py
@@ -51,8 +51,3 @@ __all__ = [
     "config",
     "tech",
 ]
-
-if __name__ == "__main__":
-    cells = sorted(PDK.cells)
-    for cell in cells:
-        print(cell)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,13 @@ authors = [
   {name = "gdsfactory", email = "contact@gdsfactory.com"}
 ]
 classifiers = [
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=8.13.3",
+  "gdsfactory~=8.15.0",
   "gplugins[sax]>=1,<2"
 ]
 description = "CornerStone PDK"
@@ -22,7 +23,7 @@ keywords = ["python"]
 license = {file = "LICENSE"}
 name = "cspdk"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 version = "0.11.2"
 
 [project.optional-dependencies]

--- a/tests/test_si220/test_netlists_mzi_.yml
+++ b/tests/test_si220/test_netlists_mzi_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc

--- a/tests/test_si220/test_netlists_mzi_rc_.yml
+++ b/tests/test_si220/test_netlists_mzi_rc_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_rc
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_rc
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_rc
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_rc
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_rc
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_rc
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_rc
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_rc

--- a/tests/test_si220/test_netlists_mzi_ro_.yml
+++ b/tests/test_si220/test_netlists_mzi_ro_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_ro
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_ro
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_ro
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_ro
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_ro
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_ro
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_ro
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.5
     settings:
       angle: 90
       cross_section: xs_ro

--- a/tests/test_si220/test_netlists_mzi_sc_.yml
+++ b/tests/test_si220/test_netlists_mzi_sc_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 8.318
       route_info_xs_sc_length: 8.318
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc

--- a/tests/test_si220/test_netlists_mzi_so_.yml
+++ b/tests/test_si220/test_netlists_mzi_so_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_so
       route_info_weight: 8.318
       route_info_xs_so_length: 8.318
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_so
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_so
       route_info_weight: 8.318
       route_info_xs_so_length: 8.318
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_so
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_so
       route_info_weight: 8.318
       route_info_xs_so_length: 8.318
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_so
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_so
       route_info_weight: 8.318
       route_info_xs_so_length: 8.318
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_so
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_so
       route_info_weight: 8.318
       route_info_xs_so_length: 8.318
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_so
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_so
       route_info_weight: 8.318
       route_info_xs_so_length: 8.318
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_so
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_so
       route_info_weight: 8.318
       route_info_xs_so_length: 8.318
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_so
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_so
       route_info_weight: 8.318
       route_info_xs_so_length: 8.318
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_so

--- a/tests/test_si220/test_netlists_ring_single_sc_.yml
+++ b/tests/test_si220/test_netlists_ring_single_sc_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 16.637
       route_info_xs_sc_length: 16.637
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_sc
       route_info_weight: 16.637
       route_info_xs_sc_length: 16.637
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_sc

--- a/tests/test_si220/test_netlists_ring_single_so_.yml
+++ b/tests/test_si220/test_netlists_ring_single_so_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_so
       route_info_weight: 16.637
       route_info_xs_so_length: 16.637
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_so
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_so
       route_info_weight: 16.637
       route_info_xs_so_length: 16.637
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_so

--- a/tests/test_si220/test_settings_bend_euler_rc_.yml
+++ b/tests/test_si220/test_settings_bend_euler_rc_.yml
@@ -9,6 +9,7 @@ info:
   route_info_type: xs_ro
   route_info_weight: 41.592
   route_info_xs_ro_length: 41.592
+  width: 0.5
 name: bend_euler_sc_RNone_A90_323c7861
 settings:
   angle: 90

--- a/tests/test_si220/test_settings_bend_euler_ro_.yml
+++ b/tests/test_si220/test_settings_bend_euler_ro_.yml
@@ -9,6 +9,7 @@ info:
   route_info_type: xs_ro
   route_info_weight: 41.592
   route_info_xs_ro_length: 41.592
+  width: 0.5
 name: bend_euler_sc_RNone_A90_a1dd07b8
 settings:
   angle: 90

--- a/tests/test_si220/test_settings_bend_euler_sc_.yml
+++ b/tests/test_si220/test_settings_bend_euler_sc_.yml
@@ -9,6 +9,7 @@ info:
   route_info_type: xs_sc
   route_info_weight: 8.318
   route_info_xs_sc_length: 8.318
+  width: 0.45
 name: bend_euler_sc_RNone_A90_3aec9813
 settings:
   angle: 90

--- a/tests/test_si220/test_settings_bend_euler_so_.yml
+++ b/tests/test_si220/test_settings_bend_euler_so_.yml
@@ -9,6 +9,7 @@ info:
   route_info_type: xs_so
   route_info_weight: 8.318
   route_info_xs_so_length: 8.318
+  width: 0.4
 name: bend_euler_sc_RNone_A90_b1011900
 settings:
   angle: 90

--- a/tests/test_si500/test_netlists_mzi_.yml
+++ b/tests/test_si500/test_netlists_mzi_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc

--- a/tests/test_si500/test_netlists_mzi_rc_.yml
+++ b/tests/test_si500/test_netlists_mzi_rc_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_rc
       route_info_weight: 41.592
       route_info_xs_rc_length: 41.592
+      width: 0.45
     settings:
       angle: 90
       cross_section: xs_rc

--- a/tests/test_si500/test_netlists_mzi_ro_.yml
+++ b/tests/test_si500/test_netlists_mzi_ro_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_ro
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_ro
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_ro
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_ro
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_ro
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_ro
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_ro
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_ro
       route_info_weight: 41.592
       route_info_xs_ro_length: 41.592
+      width: 0.4
     settings:
       angle: 90
       cross_section: xs_ro

--- a/tests/test_si500/test_settings_bend_euler_.yml
+++ b/tests/test_si500/test_settings_bend_euler_.yml
@@ -9,6 +9,7 @@ info:
   route_info_type: xs_rc
   route_info_weight: 41.592
   route_info_xs_rc_length: 41.592
+  width: 0.45
 name: bend_euler_RNone_A90_P0_ddb8ac70
 settings:
   angle: 90

--- a/tests/test_si500/test_settings_bend_euler_rc_.yml
+++ b/tests/test_si500/test_settings_bend_euler_rc_.yml
@@ -9,6 +9,7 @@ info:
   route_info_type: xs_rc
   route_info_weight: 41.592
   route_info_xs_rc_length: 41.592
+  width: 0.45
 name: bend_euler_RNone_A90_P0_ddb8ac70
 settings:
   angle: 90

--- a/tests/test_si500/test_settings_bend_euler_ro_.yml
+++ b/tests/test_si500/test_settings_bend_euler_ro_.yml
@@ -9,6 +9,7 @@ info:
   route_info_type: xs_ro
   route_info_weight: 41.592
   route_info_xs_ro_length: 41.592
+  width: 0.4
 name: bend_euler_RNone_A90_P0_3e63eab5
 settings:
   angle: 90

--- a/tests/test_sin300/test_netlists_mzi_.yml
+++ b/tests/test_sin300/test_netlists_mzi_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc

--- a/tests/test_sin300/test_netlists_mzi_nc_.yml
+++ b/tests/test_sin300/test_netlists_mzi_nc_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_nc
       route_info_weight: 41.592
       route_info_xs_nc_length: 41.592
+      width: 1.2
     settings:
       angle: 90
       cross_section: xs_nc

--- a/tests/test_sin300/test_netlists_mzi_no_.yml
+++ b/tests/test_sin300/test_netlists_mzi_no_.yml
@@ -12,6 +12,7 @@ instances:
       route_info_type: xs_no
       route_info_weight: 41.592
       route_info_xs_no_length: 41.592
+      width: 0.95
     settings:
       angle: 90
       cross_section: xs_no
@@ -31,6 +32,7 @@ instances:
       route_info_type: xs_no
       route_info_weight: 41.592
       route_info_xs_no_length: 41.592
+      width: 0.95
     settings:
       angle: 90
       cross_section: xs_no
@@ -50,6 +52,7 @@ instances:
       route_info_type: xs_no
       route_info_weight: 41.592
       route_info_xs_no_length: 41.592
+      width: 0.95
     settings:
       angle: 90
       cross_section: xs_no
@@ -69,6 +72,7 @@ instances:
       route_info_type: xs_no
       route_info_weight: 41.592
       route_info_xs_no_length: 41.592
+      width: 0.95
     settings:
       angle: 90
       cross_section: xs_no
@@ -88,6 +92,7 @@ instances:
       route_info_type: xs_no
       route_info_weight: 41.592
       route_info_xs_no_length: 41.592
+      width: 0.95
     settings:
       angle: 90
       cross_section: xs_no
@@ -107,6 +112,7 @@ instances:
       route_info_type: xs_no
       route_info_weight: 41.592
       route_info_xs_no_length: 41.592
+      width: 0.95
     settings:
       angle: 90
       cross_section: xs_no
@@ -126,6 +132,7 @@ instances:
       route_info_type: xs_no
       route_info_weight: 41.592
       route_info_xs_no_length: 41.592
+      width: 0.95
     settings:
       angle: 90
       cross_section: xs_no
@@ -145,6 +152,7 @@ instances:
       route_info_type: xs_no
       route_info_weight: 41.592
       route_info_xs_no_length: 41.592
+      width: 0.95
     settings:
       angle: 90
       cross_section: xs_no

--- a/tests/test_sin300/test_settings_bend_euler_.yml
+++ b/tests/test_sin300/test_settings_bend_euler_.yml
@@ -9,6 +9,7 @@ info:
   route_info_type: xs_nc
   route_info_weight: 41.592
   route_info_xs_nc_length: 41.592
+  width: 1.2
 name: bend_euler_RNone_A90_P0_608b8914
 settings:
   angle: 90

--- a/tests/test_sin300/test_settings_bend_euler_nc_.yml
+++ b/tests/test_sin300/test_settings_bend_euler_nc_.yml
@@ -9,6 +9,7 @@ info:
   route_info_type: xs_nc
   route_info_weight: 41.592
   route_info_xs_nc_length: 41.592
+  width: 1.2
 name: bend_euler_RNone_A90_P0_608b8914
 settings:
   angle: 90

--- a/tests/test_sin300/test_settings_bend_euler_no_.yml
+++ b/tests/test_sin300/test_settings_bend_euler_no_.yml
@@ -9,6 +9,7 @@ info:
   route_info_type: xs_no
   route_info_weight: 41.592
   route_info_xs_no_length: 41.592
+  width: 0.95
 name: bend_euler_RNone_A90_P0_ee91bb04
 settings:
   angle: 90


### PR DESCRIPTION
## Summary by Sourcery

Enhance test netlists by adding a width attribute to various instances for improved specification, and clean up the codebase by removing an unused main block from the cspdk/si220/__init__.py file.

Enhancements:
- Add width attribute to various test netlists for better specification of instance properties.

Chores:
- Remove unused main block from cspdk/si220/__init__.py.