### PR TITLE
use uv

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,11 +9,15 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     name: Sphinx docs to gh-pages
-    container: ghcr.io/gdsfactory/gdsfactory:main
     steps:
       - uses: actions/checkout@v4
-      - name: Installing the library
-        shell: bash -l {0}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
         run: |
           make install
       - name: make docs

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -10,23 +10,19 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1
+  test_code:
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
-          cache: "pip"
-          cache-dependency-path: pyproject.toml
-      - name: Test pre-commit hooks
-        run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
-          pre-commit run -a
-  test_code:
-    runs-on: ubuntu-latest
-    container: ghcr.io/gdsfactory/gdsfactory:main
-    steps:
-      - uses: actions/checkout@v4
+          python-version: '3.11'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
           make install

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ install:
 	uv sync --extra docs --extra dev
 
 test:
-	pytest -s tests/test_si220.py
-	pytest -s tests/test_si500.py
-	pytest -s tests/test_sin300.py
+	uv run pytest -s tests/test_si220.py
+	uv run pytest -s tests/test_si500.py
+	uv run pytest -s tests/test_sin300.py
 
 test-force:
 	uv run pytest -s tests/test_si220.py --force-regen
@@ -12,9 +12,9 @@ test-force:
 	uv run pytest -s tests/test_sin300.py --force-regen
 
 test-fail-fast:
-	pytest -s tests/test_si220.py -x
-	pytest -s tests/test_si500.py -x
-	pytest -s tests/test_sin300.py -x
+	uv run pytest -s tests/test_si220.py -x
+	uv run pytest -s tests/test_si500.py -x
+	uv run pytest -s tests/test_sin300.py -x
 
 update-pre:
 	pre-commit autoupdate --bleeding-edge

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	pip install -e .[dev,docs]
+	uv sync --extra docs --extra dev
 
 test:
 	pytest -s tests/test_si220.py
@@ -34,9 +34,9 @@ notebooks:
 	jupytext docs/**/*.py --to ipynb
 
 docs:
-	python .github/write_cells_si220.py
-	python .github/write_cells_si500.py
-	python .github/write_cells_sin300.py
-	jb build docs
+	uv run python .github/write_cells_si220.py
+	uv run python .github/write_cells_si500.py
+	uv run python .github/write_cells_sin300.py
+	uv run jb build docs
 
 .PHONY: drc doc docs


### PR DESCRIPTION
## Summary by Sourcery

Use `uv` to manage project dependencies and virtual environments, replacing `pip` and `make`. Update CI workflows to use `uv` for installing dependencies and running commands.

Enhancements:
- Manage project dependencies using `uv` instead of `pip` and `make`.

CI:
- Update CI workflows to use `uv` for dependency management and command execution.