### PR TITLE
better wire_corner

### DIFF
--- a/cspdk/si220/cells/primitives.py
+++ b/cspdk/si220/cells/primitives.py
@@ -48,12 +48,12 @@ straight_metal = partial(straight, cross_section="metal_routing")
 
 
 @gf.cell
-def wire_corner() -> gf.Component:
+def wire_corner(cross_section="metal_routing", **kwargs) -> gf.Component:
     """A wire corner.
 
     A wire corner is a bend for electrical routes.
     """
-    return gf.components.wire_corner(cross_section="metal_routing")
+    return gf.components.wire_corner(cross_section=cross_section, **kwargs)
 
 
 @gf.cell

--- a/cspdk/si500/cells.py
+++ b/cspdk/si500/cells.py
@@ -44,12 +44,12 @@ straight_ro = partial(straight, cross_section="xs_ro")
 
 
 @gf.cell
-def wire_corner() -> gf.Component:
+def wire_corner(cross_section="metal_routing", **kwargs) -> gf.Component:
     """A wire corner.
 
     A wire corner is a bend for electrical routes.
     """
-    return gf.components.wire_corner(cross_section="metal_routing")
+    return gf.components.wire_corner(cross_section=cross_section, **kwargs)
 
 
 @gf.cell

--- a/cspdk/sin300/cells.py
+++ b/cspdk/sin300/cells.py
@@ -44,12 +44,12 @@ straight_no = partial(straight, cross_section="xs_no")
 
 
 @gf.cell
-def wire_corner() -> Component:
+def wire_corner(cross_section="metal_routing", **kwargs) -> gf.Component:
     """A wire corner.
 
     A wire corner is a bend for electrical routes.
     """
-    return gf.components.wire_corner(cross_section="metal_routing")
+    return gf.components.wire_corner(cross_section=cross_section, **kwargs)
 
 
 @gf.cell

--- a/tests/test_si500/test_netlists_wire_corner_.yml
+++ b/tests/test_si500/test_netlists_wire_corner_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: wire_corner
+name: wire_corner_CSmetal_routing
 nets: []
 placements: {}
 ports: {}

--- a/tests/test_si500/test_settings_wire_corner_.yml
+++ b/tests/test_si500/test_settings_wire_corner_.yml
@@ -1,5 +1,6 @@
 info:
   dy: 10
   length: 10
-name: wire_corner
-settings: {}
+name: wire_corner_CSmetal_routing
+settings:
+  cross_section: metal_routing

--- a/tests/test_sin300/test_netlists_wire_corner_.yml
+++ b/tests/test_sin300/test_netlists_wire_corner_.yml
@@ -1,5 +1,5 @@
 instances: {}
-name: wire_corner
+name: wire_corner_CSmetal_routing
 nets: []
 placements: {}
 ports: {}

--- a/tests/test_sin300/test_settings_wire_corner_.yml
+++ b/tests/test_sin300/test_settings_wire_corner_.yml
@@ -1,5 +1,6 @@
 info:
   dy: 10
   length: 10
-name: wire_corner
-settings: {}
+name: wire_corner_CSmetal_routing
+settings:
+  cross_section: metal_routing


### PR DESCRIPTION
## Summary by Sourcery

Update the `wire_corner` component to accept a `cross_section` argument and additional keyword arguments.

Enhancements:
- Generalize the `wire_corner` component to allow specifying the cross_section and other parameters.

Tests:
- Update test settings and netlists to reflect the changes in the `wire_corner` component.