### PR TITLE
update_gdsfactory_9.5.9

### DIFF
--- a/cspdk/si220/cells/containers.py
+++ b/cspdk/si220/cells/containers.py
@@ -105,7 +105,7 @@ def add_fiber_single_sc(
     cross_section: CrossSectionSpec = "xs_sc",
     taper: ComponentSpec | None = None,
     input_port_names: list[str] | tuple[str, ...] | None = None,
-    fiber_spacing: float = 70,
+    pitch: float = 70,
     with_loopback: bool = True,
     loopback_spacing: float = 100.0,
     **kwargs,
@@ -122,7 +122,7 @@ def add_fiber_single_sc(
         cross_section: cross_section function.
         taper: taper spec.
         input_port_names: list of input port names to connect to grating couplers.
-        fiber_spacing: spacing between fibers.
+        pitch: spacing between fibers.
         with_loopback: adds loopback structures.
         loopback_spacing: spacing between loopback and test structure.
         kwargs: additional arguments.
@@ -169,7 +169,7 @@ def add_fiber_single_sc(
         cross_section=cross_section,
         taper=taper,
         input_port_names=input_port_names,
-        fiber_spacing=fiber_spacing,
+        pitch=pitch,
         with_loopback=with_loopback,
         loopback_spacing=loopback_spacing,
         **kwargs,
@@ -346,7 +346,7 @@ if __name__ == "__main__":
 
     PDK.activate()
 
-    c = add_fiber_array_sc()
+    c = add_fiber_single_sc()
     # c =gf.get_component(gc_sc)
     # c = pack_doe()
     c.pprint_ports()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory==9.5.7",
+  "gdsfactory==9.5.9",
   "gplugins[sax]>=1.3.3,<2"
 ]
 description = "CornerStone PDK"

--- a/tests/test_si220/test_netlists_die_.yml
+++ b/tests/test_si220/test_netlists_die_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_4c27e9f5_5181975_0:
+  grating_coupler_array_g_56cf8a55_5181975_0:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_sc
       grating_coupler: grating_coupler_rectangular_sc
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_4c27e9f5_m5181975_0:
+  grating_coupler_array_g_56cf8a55_m5181975_0:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_sc
       grating_coupler: grating_coupler_rectangular_sc
@@ -603,12 +605,12 @@ instances:
 name: die_S11470_4900_ETGD150_fd76504f
 nets: []
 placements:
-  grating_coupler_array_g_4c27e9f5_5181975_0:
+  grating_coupler_array_g_56cf8a55_5181975_0:
     mirror: false
     rotation: 90
     x: 5181.975
     y: 0
-  grating_coupler_array_g_4c27e9f5_m5181975_0:
+  grating_coupler_array_g_56cf8a55_m5181975_0:
     mirror: false
     rotation: 270
     x: -5181.975
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_4c27e9f5_5181975_0,o1
-  o10: grating_coupler_array_g_4c27e9f5_5181975_0,o10
-  o11: grating_coupler_array_g_4c27e9f5_5181975_0,o11
-  o12: grating_coupler_array_g_4c27e9f5_5181975_0,o12
-  o13: grating_coupler_array_g_4c27e9f5_m5181975_0,o1
-  o14: grating_coupler_array_g_4c27e9f5_m5181975_0,o2
-  o15: grating_coupler_array_g_4c27e9f5_m5181975_0,o3
-  o16: grating_coupler_array_g_4c27e9f5_m5181975_0,o4
-  o17: grating_coupler_array_g_4c27e9f5_m5181975_0,o5
-  o18: grating_coupler_array_g_4c27e9f5_m5181975_0,o6
-  o19: grating_coupler_array_g_4c27e9f5_m5181975_0,o7
-  o2: grating_coupler_array_g_4c27e9f5_5181975_0,o2
-  o20: grating_coupler_array_g_4c27e9f5_m5181975_0,o8
-  o21: grating_coupler_array_g_4c27e9f5_m5181975_0,o9
-  o22: grating_coupler_array_g_4c27e9f5_m5181975_0,o10
-  o23: grating_coupler_array_g_4c27e9f5_m5181975_0,o11
-  o24: grating_coupler_array_g_4c27e9f5_m5181975_0,o12
-  o3: grating_coupler_array_g_4c27e9f5_5181975_0,o3
-  o4: grating_coupler_array_g_4c27e9f5_5181975_0,o4
-  o5: grating_coupler_array_g_4c27e9f5_5181975_0,o5
-  o6: grating_coupler_array_g_4c27e9f5_5181975_0,o6
-  o7: grating_coupler_array_g_4c27e9f5_5181975_0,o7
-  o8: grating_coupler_array_g_4c27e9f5_5181975_0,o8
-  o9: grating_coupler_array_g_4c27e9f5_5181975_0,o9
+  o1: grating_coupler_array_g_56cf8a55_5181975_0,o1
+  o10: grating_coupler_array_g_56cf8a55_5181975_0,o10
+  o11: grating_coupler_array_g_56cf8a55_5181975_0,o11
+  o12: grating_coupler_array_g_56cf8a55_5181975_0,o12
+  o13: grating_coupler_array_g_56cf8a55_m5181975_0,o1
+  o14: grating_coupler_array_g_56cf8a55_m5181975_0,o2
+  o15: grating_coupler_array_g_56cf8a55_m5181975_0,o3
+  o16: grating_coupler_array_g_56cf8a55_m5181975_0,o4
+  o17: grating_coupler_array_g_56cf8a55_m5181975_0,o5
+  o18: grating_coupler_array_g_56cf8a55_m5181975_0,o6
+  o19: grating_coupler_array_g_56cf8a55_m5181975_0,o7
+  o2: grating_coupler_array_g_56cf8a55_5181975_0,o2
+  o20: grating_coupler_array_g_56cf8a55_m5181975_0,o8
+  o21: grating_coupler_array_g_56cf8a55_m5181975_0,o9
+  o22: grating_coupler_array_g_56cf8a55_m5181975_0,o10
+  o23: grating_coupler_array_g_56cf8a55_m5181975_0,o11
+  o24: grating_coupler_array_g_56cf8a55_m5181975_0,o12
+  o3: grating_coupler_array_g_56cf8a55_5181975_0,o3
+  o4: grating_coupler_array_g_56cf8a55_5181975_0,o4
+  o5: grating_coupler_array_g_56cf8a55_5181975_0,o5
+  o6: grating_coupler_array_g_56cf8a55_5181975_0,o6
+  o7: grating_coupler_array_g_56cf8a55_5181975_0,o7
+  o8: grating_coupler_array_g_56cf8a55_5181975_0,o8
+  o9: grating_coupler_array_g_56cf8a55_5181975_0,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test_si220/test_netlists_die_rc_.yml
+++ b/tests/test_si220/test_netlists_die_rc_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_9da66307_5149750_0:
+  grating_coupler_array_g_ca7315b3_5149750_0:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_rc
       grating_coupler: grating_coupler_rectangular_rc
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_9da66307_m5149750_0:
+  grating_coupler_array_g_ca7315b3_m5149750_0:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_rc
       grating_coupler: grating_coupler_rectangular_rc
@@ -603,12 +605,12 @@ instances:
 name: die_S11470_4900_ETGD150_9a6f1a79
 nets: []
 placements:
-  grating_coupler_array_g_9da66307_5149750_0:
+  grating_coupler_array_g_ca7315b3_5149750_0:
     mirror: false
     rotation: 90
     x: 5149.75
     y: 0
-  grating_coupler_array_g_9da66307_m5149750_0:
+  grating_coupler_array_g_ca7315b3_m5149750_0:
     mirror: false
     rotation: 270
     x: -5149.75
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_9da66307_5149750_0,o1
-  o10: grating_coupler_array_g_9da66307_5149750_0,o10
-  o11: grating_coupler_array_g_9da66307_5149750_0,o11
-  o12: grating_coupler_array_g_9da66307_5149750_0,o12
-  o13: grating_coupler_array_g_9da66307_m5149750_0,o1
-  o14: grating_coupler_array_g_9da66307_m5149750_0,o2
-  o15: grating_coupler_array_g_9da66307_m5149750_0,o3
-  o16: grating_coupler_array_g_9da66307_m5149750_0,o4
-  o17: grating_coupler_array_g_9da66307_m5149750_0,o5
-  o18: grating_coupler_array_g_9da66307_m5149750_0,o6
-  o19: grating_coupler_array_g_9da66307_m5149750_0,o7
-  o2: grating_coupler_array_g_9da66307_5149750_0,o2
-  o20: grating_coupler_array_g_9da66307_m5149750_0,o8
-  o21: grating_coupler_array_g_9da66307_m5149750_0,o9
-  o22: grating_coupler_array_g_9da66307_m5149750_0,o10
-  o23: grating_coupler_array_g_9da66307_m5149750_0,o11
-  o24: grating_coupler_array_g_9da66307_m5149750_0,o12
-  o3: grating_coupler_array_g_9da66307_5149750_0,o3
-  o4: grating_coupler_array_g_9da66307_5149750_0,o4
-  o5: grating_coupler_array_g_9da66307_5149750_0,o5
-  o6: grating_coupler_array_g_9da66307_5149750_0,o6
-  o7: grating_coupler_array_g_9da66307_5149750_0,o7
-  o8: grating_coupler_array_g_9da66307_5149750_0,o8
-  o9: grating_coupler_array_g_9da66307_5149750_0,o9
+  o1: grating_coupler_array_g_ca7315b3_5149750_0,o1
+  o10: grating_coupler_array_g_ca7315b3_5149750_0,o10
+  o11: grating_coupler_array_g_ca7315b3_5149750_0,o11
+  o12: grating_coupler_array_g_ca7315b3_5149750_0,o12
+  o13: grating_coupler_array_g_ca7315b3_m5149750_0,o1
+  o14: grating_coupler_array_g_ca7315b3_m5149750_0,o2
+  o15: grating_coupler_array_g_ca7315b3_m5149750_0,o3
+  o16: grating_coupler_array_g_ca7315b3_m5149750_0,o4
+  o17: grating_coupler_array_g_ca7315b3_m5149750_0,o5
+  o18: grating_coupler_array_g_ca7315b3_m5149750_0,o6
+  o19: grating_coupler_array_g_ca7315b3_m5149750_0,o7
+  o2: grating_coupler_array_g_ca7315b3_5149750_0,o2
+  o20: grating_coupler_array_g_ca7315b3_m5149750_0,o8
+  o21: grating_coupler_array_g_ca7315b3_m5149750_0,o9
+  o22: grating_coupler_array_g_ca7315b3_m5149750_0,o10
+  o23: grating_coupler_array_g_ca7315b3_m5149750_0,o11
+  o24: grating_coupler_array_g_ca7315b3_m5149750_0,o12
+  o3: grating_coupler_array_g_ca7315b3_5149750_0,o3
+  o4: grating_coupler_array_g_ca7315b3_5149750_0,o4
+  o5: grating_coupler_array_g_ca7315b3_5149750_0,o5
+  o6: grating_coupler_array_g_ca7315b3_5149750_0,o6
+  o7: grating_coupler_array_g_ca7315b3_5149750_0,o7
+  o8: grating_coupler_array_g_ca7315b3_5149750_0,o8
+  o9: grating_coupler_array_g_ca7315b3_5149750_0,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test_si220/test_netlists_die_ro_.yml
+++ b/tests/test_si220/test_netlists_die_ro_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_043784bb_5139750_0:
+  grating_coupler_array_g_88d492f7_5139750_0:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_ro
       grating_coupler: grating_coupler_rectangular_ro
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_043784bb_m5139750_0:
+  grating_coupler_array_g_88d492f7_m5139750_0:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_ro
       grating_coupler: grating_coupler_rectangular_ro
@@ -603,12 +605,12 @@ instances:
 name: die_S11470_4900_ETGD150_ac5b8b89
 nets: []
 placements:
-  grating_coupler_array_g_043784bb_5139750_0:
+  grating_coupler_array_g_88d492f7_5139750_0:
     mirror: false
     rotation: 90
     x: 5139.75
     y: 0
-  grating_coupler_array_g_043784bb_m5139750_0:
+  grating_coupler_array_g_88d492f7_m5139750_0:
     mirror: false
     rotation: 270
     x: -5139.75
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_043784bb_5139750_0,o1
-  o10: grating_coupler_array_g_043784bb_5139750_0,o10
-  o11: grating_coupler_array_g_043784bb_5139750_0,o11
-  o12: grating_coupler_array_g_043784bb_5139750_0,o12
-  o13: grating_coupler_array_g_043784bb_m5139750_0,o1
-  o14: grating_coupler_array_g_043784bb_m5139750_0,o2
-  o15: grating_coupler_array_g_043784bb_m5139750_0,o3
-  o16: grating_coupler_array_g_043784bb_m5139750_0,o4
-  o17: grating_coupler_array_g_043784bb_m5139750_0,o5
-  o18: grating_coupler_array_g_043784bb_m5139750_0,o6
-  o19: grating_coupler_array_g_043784bb_m5139750_0,o7
-  o2: grating_coupler_array_g_043784bb_5139750_0,o2
-  o20: grating_coupler_array_g_043784bb_m5139750_0,o8
-  o21: grating_coupler_array_g_043784bb_m5139750_0,o9
-  o22: grating_coupler_array_g_043784bb_m5139750_0,o10
-  o23: grating_coupler_array_g_043784bb_m5139750_0,o11
-  o24: grating_coupler_array_g_043784bb_m5139750_0,o12
-  o3: grating_coupler_array_g_043784bb_5139750_0,o3
-  o4: grating_coupler_array_g_043784bb_5139750_0,o4
-  o5: grating_coupler_array_g_043784bb_5139750_0,o5
-  o6: grating_coupler_array_g_043784bb_5139750_0,o6
-  o7: grating_coupler_array_g_043784bb_5139750_0,o7
-  o8: grating_coupler_array_g_043784bb_5139750_0,o8
-  o9: grating_coupler_array_g_043784bb_5139750_0,o9
+  o1: grating_coupler_array_g_88d492f7_5139750_0,o1
+  o10: grating_coupler_array_g_88d492f7_5139750_0,o10
+  o11: grating_coupler_array_g_88d492f7_5139750_0,o11
+  o12: grating_coupler_array_g_88d492f7_5139750_0,o12
+  o13: grating_coupler_array_g_88d492f7_m5139750_0,o1
+  o14: grating_coupler_array_g_88d492f7_m5139750_0,o2
+  o15: grating_coupler_array_g_88d492f7_m5139750_0,o3
+  o16: grating_coupler_array_g_88d492f7_m5139750_0,o4
+  o17: grating_coupler_array_g_88d492f7_m5139750_0,o5
+  o18: grating_coupler_array_g_88d492f7_m5139750_0,o6
+  o19: grating_coupler_array_g_88d492f7_m5139750_0,o7
+  o2: grating_coupler_array_g_88d492f7_5139750_0,o2
+  o20: grating_coupler_array_g_88d492f7_m5139750_0,o8
+  o21: grating_coupler_array_g_88d492f7_m5139750_0,o9
+  o22: grating_coupler_array_g_88d492f7_m5139750_0,o10
+  o23: grating_coupler_array_g_88d492f7_m5139750_0,o11
+  o24: grating_coupler_array_g_88d492f7_m5139750_0,o12
+  o3: grating_coupler_array_g_88d492f7_5139750_0,o3
+  o4: grating_coupler_array_g_88d492f7_5139750_0,o4
+  o5: grating_coupler_array_g_88d492f7_5139750_0,o5
+  o6: grating_coupler_array_g_88d492f7_5139750_0,o6
+  o7: grating_coupler_array_g_88d492f7_5139750_0,o7
+  o8: grating_coupler_array_g_88d492f7_5139750_0,o8
+  o9: grating_coupler_array_g_88d492f7_5139750_0,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test_si220/test_netlists_die_sc_.yml
+++ b/tests/test_si220/test_netlists_die_sc_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_4c27e9f5_5181975_0:
+  grating_coupler_array_g_56cf8a55_5181975_0:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_sc
       grating_coupler: grating_coupler_rectangular_sc
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_4c27e9f5_m5181975_0:
+  grating_coupler_array_g_56cf8a55_m5181975_0:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_sc
       grating_coupler: grating_coupler_rectangular_sc
@@ -603,12 +605,12 @@ instances:
 name: die_S11470_4900_ETGD150_fd76504f
 nets: []
 placements:
-  grating_coupler_array_g_4c27e9f5_5181975_0:
+  grating_coupler_array_g_56cf8a55_5181975_0:
     mirror: false
     rotation: 90
     x: 5181.975
     y: 0
-  grating_coupler_array_g_4c27e9f5_m5181975_0:
+  grating_coupler_array_g_56cf8a55_m5181975_0:
     mirror: false
     rotation: 270
     x: -5181.975
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_4c27e9f5_5181975_0,o1
-  o10: grating_coupler_array_g_4c27e9f5_5181975_0,o10
-  o11: grating_coupler_array_g_4c27e9f5_5181975_0,o11
-  o12: grating_coupler_array_g_4c27e9f5_5181975_0,o12
-  o13: grating_coupler_array_g_4c27e9f5_m5181975_0,o1
-  o14: grating_coupler_array_g_4c27e9f5_m5181975_0,o2
-  o15: grating_coupler_array_g_4c27e9f5_m5181975_0,o3
-  o16: grating_coupler_array_g_4c27e9f5_m5181975_0,o4
-  o17: grating_coupler_array_g_4c27e9f5_m5181975_0,o5
-  o18: grating_coupler_array_g_4c27e9f5_m5181975_0,o6
-  o19: grating_coupler_array_g_4c27e9f5_m5181975_0,o7
-  o2: grating_coupler_array_g_4c27e9f5_5181975_0,o2
-  o20: grating_coupler_array_g_4c27e9f5_m5181975_0,o8
-  o21: grating_coupler_array_g_4c27e9f5_m5181975_0,o9
-  o22: grating_coupler_array_g_4c27e9f5_m5181975_0,o10
-  o23: grating_coupler_array_g_4c27e9f5_m5181975_0,o11
-  o24: grating_coupler_array_g_4c27e9f5_m5181975_0,o12
-  o3: grating_coupler_array_g_4c27e9f5_5181975_0,o3
-  o4: grating_coupler_array_g_4c27e9f5_5181975_0,o4
-  o5: grating_coupler_array_g_4c27e9f5_5181975_0,o5
-  o6: grating_coupler_array_g_4c27e9f5_5181975_0,o6
-  o7: grating_coupler_array_g_4c27e9f5_5181975_0,o7
-  o8: grating_coupler_array_g_4c27e9f5_5181975_0,o8
-  o9: grating_coupler_array_g_4c27e9f5_5181975_0,o9
+  o1: grating_coupler_array_g_56cf8a55_5181975_0,o1
+  o10: grating_coupler_array_g_56cf8a55_5181975_0,o10
+  o11: grating_coupler_array_g_56cf8a55_5181975_0,o11
+  o12: grating_coupler_array_g_56cf8a55_5181975_0,o12
+  o13: grating_coupler_array_g_56cf8a55_m5181975_0,o1
+  o14: grating_coupler_array_g_56cf8a55_m5181975_0,o2
+  o15: grating_coupler_array_g_56cf8a55_m5181975_0,o3
+  o16: grating_coupler_array_g_56cf8a55_m5181975_0,o4
+  o17: grating_coupler_array_g_56cf8a55_m5181975_0,o5
+  o18: grating_coupler_array_g_56cf8a55_m5181975_0,o6
+  o19: grating_coupler_array_g_56cf8a55_m5181975_0,o7
+  o2: grating_coupler_array_g_56cf8a55_5181975_0,o2
+  o20: grating_coupler_array_g_56cf8a55_m5181975_0,o8
+  o21: grating_coupler_array_g_56cf8a55_m5181975_0,o9
+  o22: grating_coupler_array_g_56cf8a55_m5181975_0,o10
+  o23: grating_coupler_array_g_56cf8a55_m5181975_0,o11
+  o24: grating_coupler_array_g_56cf8a55_m5181975_0,o12
+  o3: grating_coupler_array_g_56cf8a55_5181975_0,o3
+  o4: grating_coupler_array_g_56cf8a55_5181975_0,o4
+  o5: grating_coupler_array_g_56cf8a55_5181975_0,o5
+  o6: grating_coupler_array_g_56cf8a55_5181975_0,o6
+  o7: grating_coupler_array_g_56cf8a55_5181975_0,o7
+  o8: grating_coupler_array_g_56cf8a55_5181975_0,o8
+  o9: grating_coupler_array_g_56cf8a55_5181975_0,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test_si220/test_netlists_die_so_.yml
+++ b/tests/test_si220/test_netlists_die_so_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_9a354930_5179800_0:
+  grating_coupler_array_g_e58659d0_5179800_0:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_so
       grating_coupler: grating_coupler_rectangular_so
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_9a354930_m5179800_0:
+  grating_coupler_array_g_e58659d0_m5179800_0:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_so
       grating_coupler: grating_coupler_rectangular_so
@@ -603,12 +605,12 @@ instances:
 name: die_S11470_4900_ETGD150_463655e4
 nets: []
 placements:
-  grating_coupler_array_g_9a354930_5179800_0:
+  grating_coupler_array_g_e58659d0_5179800_0:
     mirror: false
     rotation: 90
     x: 5179.8
     y: 0
-  grating_coupler_array_g_9a354930_m5179800_0:
+  grating_coupler_array_g_e58659d0_m5179800_0:
     mirror: false
     rotation: 270
     x: -5179.8
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_9a354930_5179800_0,o1
-  o10: grating_coupler_array_g_9a354930_5179800_0,o10
-  o11: grating_coupler_array_g_9a354930_5179800_0,o11
-  o12: grating_coupler_array_g_9a354930_5179800_0,o12
-  o13: grating_coupler_array_g_9a354930_m5179800_0,o1
-  o14: grating_coupler_array_g_9a354930_m5179800_0,o2
-  o15: grating_coupler_array_g_9a354930_m5179800_0,o3
-  o16: grating_coupler_array_g_9a354930_m5179800_0,o4
-  o17: grating_coupler_array_g_9a354930_m5179800_0,o5
-  o18: grating_coupler_array_g_9a354930_m5179800_0,o6
-  o19: grating_coupler_array_g_9a354930_m5179800_0,o7
-  o2: grating_coupler_array_g_9a354930_5179800_0,o2
-  o20: grating_coupler_array_g_9a354930_m5179800_0,o8
-  o21: grating_coupler_array_g_9a354930_m5179800_0,o9
-  o22: grating_coupler_array_g_9a354930_m5179800_0,o10
-  o23: grating_coupler_array_g_9a354930_m5179800_0,o11
-  o24: grating_coupler_array_g_9a354930_m5179800_0,o12
-  o3: grating_coupler_array_g_9a354930_5179800_0,o3
-  o4: grating_coupler_array_g_9a354930_5179800_0,o4
-  o5: grating_coupler_array_g_9a354930_5179800_0,o5
-  o6: grating_coupler_array_g_9a354930_5179800_0,o6
-  o7: grating_coupler_array_g_9a354930_5179800_0,o7
-  o8: grating_coupler_array_g_9a354930_5179800_0,o8
-  o9: grating_coupler_array_g_9a354930_5179800_0,o9
+  o1: grating_coupler_array_g_e58659d0_5179800_0,o1
+  o10: grating_coupler_array_g_e58659d0_5179800_0,o10
+  o11: grating_coupler_array_g_e58659d0_5179800_0,o11
+  o12: grating_coupler_array_g_e58659d0_5179800_0,o12
+  o13: grating_coupler_array_g_e58659d0_m5179800_0,o1
+  o14: grating_coupler_array_g_e58659d0_m5179800_0,o2
+  o15: grating_coupler_array_g_e58659d0_m5179800_0,o3
+  o16: grating_coupler_array_g_e58659d0_m5179800_0,o4
+  o17: grating_coupler_array_g_e58659d0_m5179800_0,o5
+  o18: grating_coupler_array_g_e58659d0_m5179800_0,o6
+  o19: grating_coupler_array_g_e58659d0_m5179800_0,o7
+  o2: grating_coupler_array_g_e58659d0_5179800_0,o2
+  o20: grating_coupler_array_g_e58659d0_m5179800_0,o8
+  o21: grating_coupler_array_g_e58659d0_m5179800_0,o9
+  o22: grating_coupler_array_g_e58659d0_m5179800_0,o10
+  o23: grating_coupler_array_g_e58659d0_m5179800_0,o11
+  o24: grating_coupler_array_g_e58659d0_m5179800_0,o12
+  o3: grating_coupler_array_g_e58659d0_5179800_0,o3
+  o4: grating_coupler_array_g_e58659d0_5179800_0,o4
+  o5: grating_coupler_array_g_e58659d0_5179800_0,o5
+  o6: grating_coupler_array_g_e58659d0_5179800_0,o6
+  o7: grating_coupler_array_g_e58659d0_5179800_0,o7
+  o8: grating_coupler_array_g_e58659d0_5179800_0,o8
+  o9: grating_coupler_array_g_e58659d0_5179800_0,o9
 warnings:
   electrical:
     unconnected_ports:


### PR DESCRIPTION
## Summary by Sourcery

Update gdsfactory dependency, synchronize test fixtures with new grating coupler outputs, and refine fiber container utilities

Enhancements:
- Rename fiber_spacing parameter to pitch in cspdk.si220.containers and update related docstrings
- Modify pack_doe_grid to use add_fiber_single_sc instead of add_fiber_array_sc

Build:
- Bump gdsfactory dependency to version 9.5.9

Tests:
- Revise netlist YAML fixtures across multiple die configurations to match updated grating_coupler_array component hashes and include bend_euler settings