### PR TITLE
update gdsfactory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ test:
 	# uv run pytest -s tests/test_sin300.py
 
 test-force:
-	uv run pytest -s tests/test_si220.py --force-regen
+	uv run pytest -s tests/test_si220_cband.py --force-regen
 	uv run pytest -s tests/test_si500.py --force-regen
 	uv run pytest -s tests/test_sin300.py --force-regen
 
 test-fail-fast:
-	uv run pytest -s tests/test_si220.py -x
+	uv run pytest -s tests/test_si220_cband.py -x
 	uv run pytest -s tests/test_si500.py -x
 	uv run pytest -s tests/test_sin300.py -x
 

--- a/cspdk/si500/cells.py
+++ b/cspdk/si500/cells.py
@@ -644,5 +644,5 @@ def array(
 
 
 if __name__ == "__main__":
-    c = coupler_rc()
+    c = die_rc()
     c.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory==9.5.9",
-  "gplugins[sax]>=1.3.3,<2",
+  "gdsfactory==9.7.0",
+  "gplugins[sax]>=1.3.6,<2",
   "doroutes>=0.2.0"
 ]
 description = "CornerStone PDK"
@@ -101,7 +101,7 @@ select = [
 convention = "google"
 
 [tool.setuptools.package-data]
-mypkg = ["*.csv", "*.yaml"]
+"*" = ["*.csv", "*.yaml", "*.yml", "*.gds", "*.lyp", "*.oas", "*.lyt", "*.dat", "*.nc", "*.svg"]
 
 [tool.setuptools.packages]
 find = {}

--- a/tests/test_si220_cband/test_netlists_add_fiber_array_.yml
+++ b/tests/test_si220_cband/test_netlists_add_fiber_array_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_17151b03_175500_m68933:
+  bend_euler_R10_A90_P0p5_17151b03_175500_m68933_A270_M:
     component: bend_euler
     info:
       dy: 10
@@ -20,7 +20,7 @@ instances:
       p: 0.5
       radius: 10
       width: null
-  bend_euler_R10_A90_P0p5_17151b03_185500_m14183:
+  bend_euler_R10_A90_P0p5_17151b03_185500_m14183_A180:
     component: bend_euler
     info:
       dy: 10
@@ -41,7 +41,7 @@ instances:
       p: 0.5
       radius: 10
       width: null
-  bend_euler_R10_A90_P0p5_17151b03_195500_m24183:
+  bend_euler_R10_A90_P0p5_17151b03_195500_m24183_A90:
     component: bend_euler
     info:
       dy: 10
@@ -62,7 +62,7 @@ instances:
       p: 0.5
       radius: 10
       width: null
-  bend_euler_R10_A90_P0p5_17151b03_m155500_m78933:
+  bend_euler_R10_A90_P0p5_17151b03_m155500_m78933_A180_M:
     component: bend_euler
     info:
       dy: 10
@@ -83,7 +83,7 @@ instances:
       p: 0.5
       radius: 10
       width: null
-  bend_euler_R10_A90_P0p5_17151b03_m165500_m24183:
+  bend_euler_R10_A90_P0p5_17151b03_m165500_m24183_A90:
     component: bend_euler
     info:
       dy: 10
@@ -104,7 +104,7 @@ instances:
       p: 0.5
       radius: 10
       width: null
-  bend_euler_R10_A90_P0p5_17151b03_m175500_m14183:
+  bend_euler_R10_A90_P0p5_17151b03_m175500_m14183_A180:
     component: bend_euler
     info:
       dy: 10
@@ -125,7 +125,7 @@ instances:
       p: 0.5
       radius: 10
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_68500_m5000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_68500_m5000_A90:
     component: bend_euler
     info:
       dy: 5
@@ -146,7 +146,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m58500_m5000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m58500_m5000_A90_M:
     component: bend_euler
     info:
       dy: 5
@@ -167,7 +167,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  grating_coupler_ellipti_2f8caedf_195500_m22900:
+  grating_coupler_ellipti_2f8caedf_195500_m22900_A270:
     component: grating_coupler_elliptical
     info:
       period: 0.685
@@ -177,7 +177,7 @@ instances:
       cross_section: strip
       grating_line_width: 0.315
       wavelength: 1.55
-  grating_coupler_ellipti_2f8caedf_68500_m22900:
+  grating_coupler_ellipti_2f8caedf_68500_m22900_A270:
     component: grating_coupler_elliptical
     info:
       period: 0.685
@@ -187,7 +187,7 @@ instances:
       cross_section: strip
       grating_line_width: 0.315
       wavelength: 1.55
-  grating_coupler_ellipti_2f8caedf_m185500_m22900:
+  grating_coupler_ellipti_2f8caedf_m185500_m22900_A270:
     component: grating_coupler_elliptical
     info:
       period: 0.685
@@ -197,7 +197,7 @@ instances:
       cross_section: strip
       grating_line_width: 0.315
       wavelength: 1.55
-  grating_coupler_ellipti_2f8caedf_m58500_m22900:
+  grating_coupler_ellipti_2f8caedf_m58500_m22900_A270:
     component: grating_coupler_elliptical
     info:
       period: 0.685
@@ -221,7 +221,7 @@ instances:
       length: 10
       npoints: 2
       width: null
-  straight_L19p183_CSstri_5024e896_68500_m5000:
+  straight_L19p183_CSstri_5024e896_68500_m5000_A270:
     component: straight
     info:
       length: 19.183
@@ -235,7 +235,7 @@ instances:
       length: 19.183
       npoints: 2
       width: 0.45
-  straight_L19p183_CSstri_5024e896_m58500_m5000:
+  straight_L19p183_CSstri_5024e896_m58500_m5000_A270:
     component: straight
     info:
       length: 19.183
@@ -249,7 +249,7 @@ instances:
       length: 19.183
       npoints: 2
       width: 0.45
-  straight_L321_CSstrip_WNone_N2_165500_m78933:
+  straight_L321_CSstrip_WNone_N2_165500_m78933_A180:
     component: straight
     info:
       length: 321
@@ -263,7 +263,7 @@ instances:
       length: 321
       npoints: 2
       width: null
-  straight_L44p75_CSstrip_WNone_N2_175500_m24183:
+  straight_L44p75_CSstrip_WNone_N2_175500_m24183_A270:
     component: straight
     info:
       length: 44.75
@@ -277,7 +277,7 @@ instances:
       length: 44.75
       npoints: 2
       width: null
-  straight_L44p75_CSstrip_WNone_N2_m165500_m68933:
+  straight_L44p75_CSstrip_WNone_N2_m165500_m68933_A90:
     component: straight
     info:
       length: 44.75
@@ -291,7 +291,7 @@ instances:
       length: 44.75
       npoints: 2
       width: null
-  straight_L53p5_CSstrip_W0p45_N2_63500_0:
+  straight_L53p5_CSstrip_W0p45_N2_63500_0_A180:
     component: straight
     info:
       length: 53.5
@@ -321,99 +321,99 @@ instances:
       width: 0.45
 name: add_fiber_array_Cstraig_97619bb3
 nets:
-- p1: bend_euler_R10_A90_P0p5_17151b03_175500_m68933,o1
-  p2: straight_L44p75_CSstrip_WNone_N2_175500_m24183,o2
-- p1: bend_euler_R10_A90_P0p5_17151b03_175500_m68933,o2
-  p2: straight_L321_CSstrip_WNone_N2_165500_m78933,o1
-- p1: bend_euler_R10_A90_P0p5_17151b03_185500_m14183,o1
-  p2: bend_euler_R10_A90_P0p5_17151b03_195500_m24183,o2
-- p1: bend_euler_R10_A90_P0p5_17151b03_185500_m14183,o2
-  p2: straight_L44p75_CSstrip_WNone_N2_175500_m24183,o1
-- p1: bend_euler_R10_A90_P0p5_17151b03_195500_m24183,o1
-  p2: grating_coupler_ellipti_2f8caedf_195500_m22900,o1
-- p1: bend_euler_R10_A90_P0p5_17151b03_m155500_m78933,o1
-  p2: straight_L321_CSstrip_WNone_N2_165500_m78933,o2
-- p1: bend_euler_R10_A90_P0p5_17151b03_m155500_m78933,o2
-  p2: straight_L44p75_CSstrip_WNone_N2_m165500_m68933,o1
-- p1: bend_euler_R10_A90_P0p5_17151b03_m165500_m24183,o1
-  p2: straight_L44p75_CSstrip_WNone_N2_m165500_m68933,o2
-- p1: bend_euler_R10_A90_P0p5_17151b03_m165500_m24183,o2
-  p2: bend_euler_R10_A90_P0p5_17151b03_m175500_m14183,o1
-- p1: bend_euler_R10_A90_P0p5_17151b03_m175500_m14183,o2
-  p2: grating_coupler_ellipti_2f8caedf_m185500_m22900,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_68500_m5000,o1
-  p2: straight_L19p183_CSstri_5024e896_68500_m5000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_68500_m5000,o2
-  p2: straight_L53p5_CSstrip_W0p45_N2_63500_0,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m58500_m5000,o1
-  p2: straight_L19p183_CSstri_5024e896_m58500_m5000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m58500_m5000,o2
+- p1: bend_euler_R10_A90_P0p5_17151b03_175500_m68933_A270_M,o1
+  p2: straight_L44p75_CSstrip_WNone_N2_175500_m24183_A270,o2
+- p1: bend_euler_R10_A90_P0p5_17151b03_175500_m68933_A270_M,o2
+  p2: straight_L321_CSstrip_WNone_N2_165500_m78933_A180,o1
+- p1: bend_euler_R10_A90_P0p5_17151b03_185500_m14183_A180,o1
+  p2: bend_euler_R10_A90_P0p5_17151b03_195500_m24183_A90,o2
+- p1: bend_euler_R10_A90_P0p5_17151b03_185500_m14183_A180,o2
+  p2: straight_L44p75_CSstrip_WNone_N2_175500_m24183_A270,o1
+- p1: bend_euler_R10_A90_P0p5_17151b03_195500_m24183_A90,o1
+  p2: grating_coupler_ellipti_2f8caedf_195500_m22900_A270,o1
+- p1: bend_euler_R10_A90_P0p5_17151b03_m155500_m78933_A180_M,o1
+  p2: straight_L321_CSstrip_WNone_N2_165500_m78933_A180,o2
+- p1: bend_euler_R10_A90_P0p5_17151b03_m155500_m78933_A180_M,o2
+  p2: straight_L44p75_CSstrip_WNone_N2_m165500_m68933_A90,o1
+- p1: bend_euler_R10_A90_P0p5_17151b03_m165500_m24183_A90,o1
+  p2: straight_L44p75_CSstrip_WNone_N2_m165500_m68933_A90,o2
+- p1: bend_euler_R10_A90_P0p5_17151b03_m165500_m24183_A90,o2
+  p2: bend_euler_R10_A90_P0p5_17151b03_m175500_m14183_A180,o1
+- p1: bend_euler_R10_A90_P0p5_17151b03_m175500_m14183_A180,o2
+  p2: grating_coupler_ellipti_2f8caedf_m185500_m22900_A270,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_68500_m5000_A90,o1
+  p2: straight_L19p183_CSstri_5024e896_68500_m5000_A270,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_68500_m5000_A90,o2
+  p2: straight_L53p5_CSstrip_W0p45_N2_63500_0_A180,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m58500_m5000_A90_M,o1
+  p2: straight_L19p183_CSstri_5024e896_m58500_m5000_A270,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m58500_m5000_A90_M,o2
   p2: straight_L53p5_CSstrip_W0p45_N2_m53500_0,o1
-- p1: grating_coupler_ellipti_2f8caedf_68500_m22900,o1
-  p2: straight_L19p183_CSstri_5024e896_68500_m5000,o2
-- p1: grating_coupler_ellipti_2f8caedf_m58500_m22900,o1
-  p2: straight_L19p183_CSstri_5024e896_m58500_m5000,o2
+- p1: grating_coupler_ellipti_2f8caedf_68500_m22900_A270,o1
+  p2: straight_L19p183_CSstri_5024e896_68500_m5000_A270,o2
+- p1: grating_coupler_ellipti_2f8caedf_m58500_m22900_A270,o1
+  p2: straight_L19p183_CSstri_5024e896_m58500_m5000_A270,o2
 - p1: straight_L10_CSstrip_WNone_N2_0_0,o1
   p2: straight_L53p5_CSstrip_W0p45_N2_m53500_0,o2
 - p1: straight_L10_CSstrip_WNone_N2_0_0,o2
-  p2: straight_L53p5_CSstrip_W0p45_N2_63500_0,o2
+  p2: straight_L53p5_CSstrip_W0p45_N2_63500_0_A180,o2
 placements:
-  bend_euler_R10_A90_P0p5_17151b03_175500_m68933:
+  bend_euler_R10_A90_P0p5_17151b03_175500_m68933_A270_M:
     mirror: true
     rotation: 270
     x: 175.5
     y: -68.933
-  bend_euler_R10_A90_P0p5_17151b03_185500_m14183:
+  bend_euler_R10_A90_P0p5_17151b03_185500_m14183_A180:
     mirror: false
     rotation: 180
     x: 185.5
     y: -14.183
-  bend_euler_R10_A90_P0p5_17151b03_195500_m24183:
+  bend_euler_R10_A90_P0p5_17151b03_195500_m24183_A90:
     mirror: false
     rotation: 90
     x: 195.5
     y: -24.183
-  bend_euler_R10_A90_P0p5_17151b03_m155500_m78933:
+  bend_euler_R10_A90_P0p5_17151b03_m155500_m78933_A180_M:
     mirror: true
     rotation: 180
     x: -155.5
     y: -78.933
-  bend_euler_R10_A90_P0p5_17151b03_m165500_m24183:
+  bend_euler_R10_A90_P0p5_17151b03_m165500_m24183_A90:
     mirror: false
     rotation: 90
     x: -165.5
     y: -24.183
-  bend_euler_R10_A90_P0p5_17151b03_m175500_m14183:
+  bend_euler_R10_A90_P0p5_17151b03_m175500_m14183_A180:
     mirror: false
     rotation: 180
     x: -175.5
     y: -14.183
-  bend_euler_RNone_A90_P0_fbfa4d8c_68500_m5000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_68500_m5000_A90:
     mirror: false
     rotation: 90
     x: 68.5
     y: -5
-  bend_euler_RNone_A90_P0_fbfa4d8c_m58500_m5000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m58500_m5000_A90_M:
     mirror: true
     rotation: 90
     x: -58.5
     y: -5
-  grating_coupler_ellipti_2f8caedf_195500_m22900:
+  grating_coupler_ellipti_2f8caedf_195500_m22900_A270:
     mirror: false
     rotation: 270
     x: 195.5
     y: -22.9
-  grating_coupler_ellipti_2f8caedf_68500_m22900:
+  grating_coupler_ellipti_2f8caedf_68500_m22900_A270:
     mirror: false
     rotation: 270
     x: 68.5
     y: -22.9
-  grating_coupler_ellipti_2f8caedf_m185500_m22900:
+  grating_coupler_ellipti_2f8caedf_m185500_m22900_A270:
     mirror: false
     rotation: 270
     x: -185.5
     y: -22.9
-  grating_coupler_ellipti_2f8caedf_m58500_m22900:
+  grating_coupler_ellipti_2f8caedf_m58500_m22900_A270:
     mirror: false
     rotation: 270
     x: -58.5
@@ -423,32 +423,32 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L19p183_CSstri_5024e896_68500_m5000:
+  straight_L19p183_CSstri_5024e896_68500_m5000_A270:
     mirror: false
     rotation: 270
     x: 68.5
     y: -5
-  straight_L19p183_CSstri_5024e896_m58500_m5000:
+  straight_L19p183_CSstri_5024e896_m58500_m5000_A270:
     mirror: false
     rotation: 270
     x: -58.5
     y: -5
-  straight_L321_CSstrip_WNone_N2_165500_m78933:
+  straight_L321_CSstrip_WNone_N2_165500_m78933_A180:
     mirror: false
     rotation: 180
     x: 165.5
     y: -78.933
-  straight_L44p75_CSstrip_WNone_N2_175500_m24183:
+  straight_L44p75_CSstrip_WNone_N2_175500_m24183_A270:
     mirror: false
     rotation: 270
     x: 175.5
     y: -24.183
-  straight_L44p75_CSstrip_WNone_N2_m165500_m68933:
+  straight_L44p75_CSstrip_WNone_N2_m165500_m68933_A90:
     mirror: false
     rotation: 90
     x: -165.5
     y: -68.933
-  straight_L53p5_CSstrip_W0p45_N2_63500_0:
+  straight_L53p5_CSstrip_W0p45_N2_63500_0_A180:
     mirror: false
     rotation: 180
     x: 63.5
@@ -459,7 +459,7 @@ placements:
     x: -53.5
     y: 0
 ports:
-  loopback1: grating_coupler_ellipti_2f8caedf_m185500_m22900,o2
-  loopback2: grating_coupler_ellipti_2f8caedf_195500_m22900,o2
-  o1: grating_coupler_ellipti_2f8caedf_m58500_m22900,o2
-  o2: grating_coupler_ellipti_2f8caedf_68500_m22900,o2
+  loopback1: grating_coupler_ellipti_2f8caedf_m185500_m22900_A270,o2
+  loopback2: grating_coupler_ellipti_2f8caedf_195500_m22900_A270,o2
+  o1: grating_coupler_ellipti_2f8caedf_m58500_m22900_A270,o2
+  o2: grating_coupler_ellipti_2f8caedf_68500_m22900_A270,o2

--- a/tests/test_si220_cband/test_netlists_add_fiber_single_.yml
+++ b/tests/test_si220_cband/test_netlists_add_fiber_single_.yml
@@ -1,5 +1,5 @@
 instances:
-  grating_coupler_ellipti_2f8caedf_0_m37900:
+  grating_coupler_ellipti_2f8caedf_0_m37900_A270:
     component: grating_coupler_elliptical
     info:
       period: 0.685
@@ -9,7 +9,7 @@ instances:
       cross_section: strip
       grating_line_width: 0.315
       wavelength: 1.55
-  grating_coupler_ellipti_2f8caedf_141258_27900:
+  grating_coupler_ellipti_2f8caedf_141258_27900_A90:
     component: grating_coupler_elliptical
     info:
       period: 0.685
@@ -19,7 +19,7 @@ instances:
       cross_section: strip
       grating_line_width: 0.315
       wavelength: 1.55
-  grating_coupler_ellipti_2f8caedf_141258_m37900:
+  grating_coupler_ellipti_2f8caedf_141258_m37900_A270:
     component: grating_coupler_elliptical
     info:
       period: 0.685
@@ -29,7 +29,7 @@ instances:
       cross_section: strip
       grating_line_width: 0.315
       wavelength: 1.55
-  straight_L29p183_CSstri_637c02b2_0_m10000:
+  straight_L29p183_CSstri_637c02b2_0_m10000_A270:
     component: straight
     info:
       length: 29.183
@@ -43,7 +43,7 @@ instances:
       length: 29.183
       npoints: 2
       width: 0.45
-  straight_L68p3660000000_52a65daf_141258_m39183:
+  straight_L68p3660000000_52a65daf_141258_m39183_A90:
     component: straight
     info:
       length: 68.366
@@ -59,48 +59,48 @@ instances:
       width: null
 name: add_fiber_single_Cstrai_74435255
 nets:
-- p1: grating_coupler_ellipti_2f8caedf_0_m37900,o1
-  p2: straight_L29p183_CSstri_637c02b2_0_m10000,o2
-- p1: grating_coupler_ellipti_2f8caedf_141258_27900,o1
-  p2: straight_L68p3660000000_52a65daf_141258_m39183,o2
-- p1: grating_coupler_ellipti_2f8caedf_141258_m37900,o1
-  p2: straight_L68p3660000000_52a65daf_141258_m39183,o1
+- p1: grating_coupler_ellipti_2f8caedf_0_m37900_A270,o1
+  p2: straight_L29p183_CSstri_637c02b2_0_m10000_A270,o2
+- p1: grating_coupler_ellipti_2f8caedf_141258_27900_A90,o1
+  p2: straight_L68p3660000000_52a65daf_141258_m39183_A90,o2
+- p1: grating_coupler_ellipti_2f8caedf_141258_m37900_A270,o1
+  p2: straight_L68p3660000000_52a65daf_141258_m39183_A90,o1
 placements:
-  grating_coupler_ellipti_2f8caedf_0_m37900:
+  grating_coupler_ellipti_2f8caedf_0_m37900_A270:
     mirror: false
     rotation: 270
     x: 0
     y: -37.9
-  grating_coupler_ellipti_2f8caedf_141258_27900:
+  grating_coupler_ellipti_2f8caedf_141258_27900_A90:
     mirror: false
     rotation: 90
     x: 141.258
     y: 27.9
-  grating_coupler_ellipti_2f8caedf_141258_m37900:
+  grating_coupler_ellipti_2f8caedf_141258_m37900_A270:
     mirror: false
     rotation: 270
     x: 141.258
     y: -37.9
-  straight_L29p183_CSstri_637c02b2_0_m10000:
+  straight_L29p183_CSstri_637c02b2_0_m10000_A270:
     mirror: false
     rotation: 270
     x: 0
     y: -10
-  straight_L68p3660000000_52a65daf_141258_m39183:
+  straight_L68p3660000000_52a65daf_141258_m39183_A90:
     mirror: false
     rotation: 90
     x: 141.258
     y: -39.183
 ports:
-  loopback1: grating_coupler_ellipti_2f8caedf_141258_m37900,o2
-  loopback2: grating_coupler_ellipti_2f8caedf_141258_27900,o2
-  o2: grating_coupler_ellipti_2f8caedf_0_m37900,o2
+  loopback1: grating_coupler_ellipti_2f8caedf_141258_m37900_A270,o2
+  loopback2: grating_coupler_ellipti_2f8caedf_141258_27900_A90,o2
+  o2: grating_coupler_ellipti_2f8caedf_0_m37900_A270,o2
 warnings:
   optical:
     unconnected_ports:
     - message: 1 unconnected optical ports!
       ports:
-      - straight_L29p183_CSstri_637c02b2_0_m10000,o1
+      - straight_L29p183_CSstri_637c02b2_0_m10000_A270,o1
       values:
       - - 0
         - -10

--- a/tests/test_si220_cband/test_netlists_mzi_.yml
+++ b/tests/test_si220_cband/test_netlists_mzi_.yml
@@ -170,16 +170,16 @@ instances:
   cp1:
     component: coupler
     info:
-      length: 10.188
       min_bend_radius: 11.807
+      path_length: 40.376
     settings:
       gap: 0.27
       length: 20
   cp2:
     component: coupler
     info:
-      length: 10.188
       min_bend_radius: 11.807
+      path_length: 40.376
     settings:
       gap: 0.27
       length: 20

--- a/tests/test_si220_cband/test_netlists_ring_double_.yml
+++ b/tests/test_si220_cband/test_netlists_ring_double_.yml
@@ -9,7 +9,7 @@ instances:
       length_x: 0.01
       radius: 10
       straight: straight
-  coupler_ring_LX0p01_G0p_dd693657_m10_21450:
+  coupler_ring_LX0p01_G0p_dd693657_m10_21450_A180:
     component: coupler_ring
     info: {}
     settings:
@@ -19,7 +19,7 @@ instances:
       length_x: 0.01
       radius: 10
       straight: straight
-  straight_L0p01_CSstrip_WNone_N2_10000_10730:
+  straight_L0p01_CSstrip_WNone_N2_10000_10730_A270:
     component: straight
     info:
       length: 0.01
@@ -33,7 +33,7 @@ instances:
       length: 0.01
       npoints: 2
       width: null
-  straight_L0p01_CSstrip_WNone_N2_m10010_10720:
+  straight_L0p01_CSstrip_WNone_N2_m10010_10720_A90:
     component: straight
     info:
       length: 0.01
@@ -50,30 +50,30 @@ instances:
 name: ring_double_G0p27_GTNon_7e33e492
 nets:
 - p1: coupler_ring_LX0p01_G0p_dd693657_0_0,o2
-  p2: straight_L0p01_CSstrip_WNone_N2_m10010_10720,o1
+  p2: straight_L0p01_CSstrip_WNone_N2_m10010_10720_A90,o1
 - p1: coupler_ring_LX0p01_G0p_dd693657_0_0,o3
-  p2: straight_L0p01_CSstrip_WNone_N2_10000_10730,o2
-- p1: coupler_ring_LX0p01_G0p_dd693657_m10_21450,o2
-  p2: straight_L0p01_CSstrip_WNone_N2_10000_10730,o1
-- p1: coupler_ring_LX0p01_G0p_dd693657_m10_21450,o3
-  p2: straight_L0p01_CSstrip_WNone_N2_m10010_10720,o2
+  p2: straight_L0p01_CSstrip_WNone_N2_10000_10730_A270,o2
+- p1: coupler_ring_LX0p01_G0p_dd693657_m10_21450_A180,o2
+  p2: straight_L0p01_CSstrip_WNone_N2_10000_10730_A270,o1
+- p1: coupler_ring_LX0p01_G0p_dd693657_m10_21450_A180,o3
+  p2: straight_L0p01_CSstrip_WNone_N2_m10010_10720_A90,o2
 placements:
   coupler_ring_LX0p01_G0p_dd693657_0_0:
     mirror: false
     rotation: 0
     x: 0
     y: 0
-  coupler_ring_LX0p01_G0p_dd693657_m10_21450:
+  coupler_ring_LX0p01_G0p_dd693657_m10_21450_A180:
     mirror: false
     rotation: 180
     x: -0.01
     y: 21.45
-  straight_L0p01_CSstrip_WNone_N2_10000_10730:
+  straight_L0p01_CSstrip_WNone_N2_10000_10730_A270:
     mirror: false
     rotation: 270
     x: 10
     y: 10.73
-  straight_L0p01_CSstrip_WNone_N2_m10010_10720:
+  straight_L0p01_CSstrip_WNone_N2_m10010_10720_A90:
     mirror: false
     rotation: 90
     x: -10.01
@@ -81,5 +81,5 @@ placements:
 ports:
   o1: coupler_ring_LX0p01_G0p_dd693657_0_0,o1
   o2: coupler_ring_LX0p01_G0p_dd693657_0_0,o4
-  o3: coupler_ring_LX0p01_G0p_dd693657_m10_21450,o4
-  o4: coupler_ring_LX0p01_G0p_dd693657_m10_21450,o1
+  o3: coupler_ring_LX0p01_G0p_dd693657_m10_21450_A180,o4
+  o4: coupler_ring_LX0p01_G0p_dd693657_m10_21450_A180,o1

--- a/tests/test_si220_cband/test_netlists_ring_single_.yml
+++ b/tests/test_si220_cband/test_netlists_ring_single_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R10_A90_P0p5_17151b03_10000_11320:
+  bend_euler_R10_A90_P0p5_17151b03_10000_11320_A90:
     component: bend_euler
     info:
       dy: 10
@@ -20,7 +20,7 @@ instances:
       p: 0.5
       radius: 10
       width: null
-  bend_euler_R10_A90_P0p5_17151b03_m4000_21320:
+  bend_euler_R10_A90_P0p5_17151b03_m4000_21320_A180:
     component: bend_euler
     info:
       dy: 10
@@ -51,7 +51,7 @@ instances:
       length_x: 4
       radius: 10
       straight: straight
-  straight_L0p6_CSstrip_WNone_N2_10000_11320:
+  straight_L0p6_CSstrip_WNone_N2_10000_11320_A270:
     component: straight
     info:
       length: 0.6
@@ -65,7 +65,7 @@ instances:
       length: 0.6
       npoints: 2
       width: null
-  straight_L0p6_CSstrip_WNone_N2_m14000_10720:
+  straight_L0p6_CSstrip_WNone_N2_m14000_10720_A90:
     component: straight
     info:
       length: 0.6
@@ -79,7 +79,7 @@ instances:
       length: 0.6
       npoints: 2
       width: null
-  straight_L4_CSstrip_WNone_N2_0_21320:
+  straight_L4_CSstrip_WNone_N2_0_21320_A180:
     component: straight
     info:
       length: 4
@@ -95,25 +95,25 @@ instances:
       width: null
 name: ring_single_G0p27_R10_L_c4ff7786
 nets:
-- p1: bend_euler_R10_A90_P0p5_17151b03_10000_11320,o1
-  p2: straight_L0p6_CSstrip_WNone_N2_10000_11320,o1
-- p1: bend_euler_R10_A90_P0p5_17151b03_10000_11320,o2
-  p2: straight_L4_CSstrip_WNone_N2_0_21320,o1
-- p1: bend_euler_R10_A90_P0p5_17151b03_m4000_21320,o1
-  p2: straight_L4_CSstrip_WNone_N2_0_21320,o2
-- p1: bend_euler_R10_A90_P0p5_17151b03_m4000_21320,o2
-  p2: straight_L0p6_CSstrip_WNone_N2_m14000_10720,o2
+- p1: bend_euler_R10_A90_P0p5_17151b03_10000_11320_A90,o1
+  p2: straight_L0p6_CSstrip_WNone_N2_10000_11320_A270,o1
+- p1: bend_euler_R10_A90_P0p5_17151b03_10000_11320_A90,o2
+  p2: straight_L4_CSstrip_WNone_N2_0_21320_A180,o1
+- p1: bend_euler_R10_A90_P0p5_17151b03_m4000_21320_A180,o1
+  p2: straight_L4_CSstrip_WNone_N2_0_21320_A180,o2
+- p1: bend_euler_R10_A90_P0p5_17151b03_m4000_21320_A180,o2
+  p2: straight_L0p6_CSstrip_WNone_N2_m14000_10720_A90,o2
 - p1: coupler_ring_LX4_G0p27__d3277347_0_0,o2
-  p2: straight_L0p6_CSstrip_WNone_N2_m14000_10720,o1
+  p2: straight_L0p6_CSstrip_WNone_N2_m14000_10720_A90,o1
 - p1: coupler_ring_LX4_G0p27__d3277347_0_0,o3
-  p2: straight_L0p6_CSstrip_WNone_N2_10000_11320,o2
+  p2: straight_L0p6_CSstrip_WNone_N2_10000_11320_A270,o2
 placements:
-  bend_euler_R10_A90_P0p5_17151b03_10000_11320:
+  bend_euler_R10_A90_P0p5_17151b03_10000_11320_A90:
     mirror: false
     rotation: 90
     x: 10
     y: 11.32
-  bend_euler_R10_A90_P0p5_17151b03_m4000_21320:
+  bend_euler_R10_A90_P0p5_17151b03_m4000_21320_A180:
     mirror: false
     rotation: 180
     x: -4
@@ -123,17 +123,17 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L0p6_CSstrip_WNone_N2_10000_11320:
+  straight_L0p6_CSstrip_WNone_N2_10000_11320_A270:
     mirror: false
     rotation: 270
     x: 10
     y: 11.32
-  straight_L0p6_CSstrip_WNone_N2_m14000_10720:
+  straight_L0p6_CSstrip_WNone_N2_m14000_10720_A90:
     mirror: false
     rotation: 90
     x: -14
     y: 10.72
-  straight_L4_CSstrip_WNone_N2_0_21320:
+  straight_L4_CSstrip_WNone_N2_0_21320_A180:
     mirror: false
     rotation: 180
     x: 0

--- a/tests/test_si220_cband/test_netlists_spiral_.yml
+++ b/tests/test_si220_cband/test_netlists_spiral_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_RNone_A90_P0_fbfa4d8c_0_0:
+  bend_euler_RNone_A90_P0_fbfa4d8c_0_0_A180_M:
     component: bend_euler
     info:
       dy: 5
@@ -62,7 +62,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_105000_8000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_105000_8000_A90:
     component: bend_euler
     info:
       dy: 5
@@ -104,7 +104,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_108000_11000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_108000_11000_A90:
     component: bend_euler
     info:
       dy: 5
@@ -146,7 +146,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_111000_14000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_111000_14000_A90:
     component: bend_euler
     info:
       dy: 5
@@ -188,7 +188,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_114000_17000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_114000_17000_A90:
     component: bend_euler
     info:
       dy: 5
@@ -230,7 +230,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_117000_20000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_117000_20000_A90:
     component: bend_euler
     info:
       dy: 5
@@ -251,7 +251,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_120000_23000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_120000_23000_A90:
     component: bend_euler
     info:
       dy: 5
@@ -272,7 +272,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m10000_10000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m10000_10000_A180:
     component: bend_euler
     info:
       dy: 5
@@ -293,7 +293,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m13000_13000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m13000_13000_A180:
     component: bend_euler
     info:
       dy: 5
@@ -314,7 +314,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m15000_2000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m15000_2000_A270:
     component: bend_euler
     info:
       dy: 5
@@ -335,7 +335,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m16000_16000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m16000_16000_A180:
     component: bend_euler
     info:
       dy: 5
@@ -356,7 +356,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m18000_m1000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m18000_m1000_A270:
     component: bend_euler
     info:
       dy: 5
@@ -377,7 +377,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m19000_19000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m19000_19000_A180:
     component: bend_euler
     info:
       dy: 5
@@ -398,7 +398,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m21000_m4000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m21000_m4000_A270:
     component: bend_euler
     info:
       dy: 5
@@ -419,7 +419,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m22000_22000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m22000_22000_A180:
     component: bend_euler
     info:
       dy: 5
@@ -440,7 +440,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m24000_m7000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m24000_m7000_A270:
     component: bend_euler
     info:
       dy: 5
@@ -461,7 +461,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m25000_25000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m25000_25000_A180:
     component: bend_euler
     info:
       dy: 5
@@ -482,7 +482,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m27000_m10000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m27000_m10000_A270:
     component: bend_euler
     info:
       dy: 5
@@ -503,7 +503,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m28000_28000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m28000_28000_A180:
     component: bend_euler
     info:
       dy: 5
@@ -524,7 +524,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m30000_m13000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m30000_m13000_A270:
     component: bend_euler
     info:
       dy: 5
@@ -545,7 +545,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m33000_m16000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m33000_m16000_A270:
     component: bend_euler
     info:
       dy: 5
@@ -566,7 +566,7 @@ instances:
       p: 0.5
       radius: null
       width: null
-  bend_euler_RNone_A90_P0_fbfa4d8c_m5000_5000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m5000_5000_A90:
     component: bend_euler
     info:
       dy: 5
@@ -601,7 +601,7 @@ instances:
       length: 100
       npoints: 2
       width: null
-  straight_L113_CSstrip_WNone_N2_100000_13000:
+  straight_L113_CSstrip_WNone_N2_100000_13000_A180:
     component: straight
     info:
       length: 113
@@ -629,7 +629,7 @@ instances:
       length: 113
       npoints: 2
       width: null
-  straight_L119_CSstrip_WNone_N2_103000_16000:
+  straight_L119_CSstrip_WNone_N2_103000_16000_A180:
     component: straight
     info:
       length: 119
@@ -657,7 +657,7 @@ instances:
       length: 119
       npoints: 2
       width: null
-  straight_L125_CSstrip_WNone_N2_106000_19000:
+  straight_L125_CSstrip_WNone_N2_106000_19000_A180:
     component: straight
     info:
       length: 125
@@ -685,7 +685,7 @@ instances:
       length: 125
       npoints: 2
       width: null
-  straight_L131_CSstrip_WNone_N2_109000_22000:
+  straight_L131_CSstrip_WNone_N2_109000_22000_A180:
     component: straight
     info:
       length: 131
@@ -713,7 +713,7 @@ instances:
       length: 131
       npoints: 2
       width: null
-  straight_L137_CSstrip_WNone_N2_112000_25000:
+  straight_L137_CSstrip_WNone_N2_112000_25000_A180:
     component: straight
     info:
       length: 137
@@ -741,7 +741,7 @@ instances:
       length: 137
       npoints: 2
       width: null
-  straight_L143_CSstrip_WNone_N2_115000_28000:
+  straight_L143_CSstrip_WNone_N2_115000_28000_A180:
     component: straight
     info:
       length: 143
@@ -783,7 +783,7 @@ instances:
       length: 149
       npoints: 2
       width: null
-  straight_L15_CSstrip_WNone_N2_111000_m1000:
+  straight_L15_CSstrip_WNone_N2_111000_m1000_A90:
     component: straight
     info:
       length: 15
@@ -797,7 +797,7 @@ instances:
       length: 15
       npoints: 2
       width: null
-  straight_L15_CSstrip_WNone_N2_m21000_11000:
+  straight_L15_CSstrip_WNone_N2_m21000_11000_A270:
     component: straight
     info:
       length: 15
@@ -811,7 +811,7 @@ instances:
       length: 15
       npoints: 2
       width: null
-  straight_L21_CSstrip_WNone_N2_114000_m4000:
+  straight_L21_CSstrip_WNone_N2_114000_m4000_A90:
     component: straight
     info:
       length: 21
@@ -825,7 +825,7 @@ instances:
       length: 21
       npoints: 2
       width: null
-  straight_L21_CSstrip_WNone_N2_m24000_14000:
+  straight_L21_CSstrip_WNone_N2_m24000_14000_A270:
     component: straight
     info:
       length: 21
@@ -839,7 +839,7 @@ instances:
       length: 21
       npoints: 2
       width: null
-  straight_L27_CSstrip_WNone_N2_117000_m7000:
+  straight_L27_CSstrip_WNone_N2_117000_m7000_A90:
     component: straight
     info:
       length: 27
@@ -853,7 +853,7 @@ instances:
       length: 27
       npoints: 2
       width: null
-  straight_L27_CSstrip_WNone_N2_m27000_17000:
+  straight_L27_CSstrip_WNone_N2_m27000_17000_A270:
     component: straight
     info:
       length: 27
@@ -867,7 +867,7 @@ instances:
       length: 27
       npoints: 2
       width: null
-  straight_L33_CSstrip_WNone_N2_120000_m10000:
+  straight_L33_CSstrip_WNone_N2_120000_m10000_A90:
     component: straight
     info:
       length: 33
@@ -881,7 +881,7 @@ instances:
       length: 33
       npoints: 2
       width: null
-  straight_L33_CSstrip_WNone_N2_m30000_20000:
+  straight_L33_CSstrip_WNone_N2_m30000_20000_A270:
     component: straight
     info:
       length: 33
@@ -895,7 +895,7 @@ instances:
       length: 33
       npoints: 2
       width: null
-  straight_L39_CSstrip_WNone_N2_m33000_23000:
+  straight_L39_CSstrip_WNone_N2_m33000_23000_A270:
     component: straight
     info:
       length: 39
@@ -909,7 +909,7 @@ instances:
       length: 39
       npoints: 2
       width: null
-  straight_L3_CSstrip_WNone_N2_105000_5000:
+  straight_L3_CSstrip_WNone_N2_105000_5000_A90:
     component: straight
     info:
       length: 3
@@ -923,7 +923,7 @@ instances:
       length: 3
       npoints: 2
       width: null
-  straight_L3_CSstrip_WNone_N2_m15000_5000:
+  straight_L3_CSstrip_WNone_N2_m15000_5000_A270:
     component: straight
     info:
       length: 3
@@ -937,7 +937,7 @@ instances:
       length: 3
       npoints: 2
       width: null
-  straight_L9_CSstrip_WNone_N2_108000_2000:
+  straight_L9_CSstrip_WNone_N2_108000_2000_A90:
     component: straight
     info:
       length: 9
@@ -951,7 +951,7 @@ instances:
       length: 9
       npoints: 2
       width: null
-  straight_L9_CSstrip_WNone_N2_m18000_8000:
+  straight_L9_CSstrip_WNone_N2_m18000_8000_A270:
     component: straight
     info:
       length: 9
@@ -967,116 +967,116 @@ instances:
       width: null
 name: spiral_L100_CSstrip_S3_NL6
 nets:
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_0_0,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_0_0_A180_M,o1
   p2: straight_L100_CSstrip_WNone_N2_0_0,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_0_0,o2
-  p2: bend_euler_RNone_A90_P0_fbfa4d8c_m5000_5000,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_0_0_A180_M,o2
+  p2: bend_euler_RNone_A90_P0_fbfa4d8c_m5000_5000_A90,o1
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_100000_0,o1
   p2: straight_L100_CSstrip_WNone_N2_0_0,o2
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_100000_0,o2
-  p2: straight_L3_CSstrip_WNone_N2_105000_5000,o1
+  p2: straight_L3_CSstrip_WNone_N2_105000_5000_A90,o1
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_103000_m3000,o1
   p2: straight_L113_CSstrip_WNone_N2_m10000_m3000,o2
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_103000_m3000,o2
-  p2: straight_L9_CSstrip_WNone_N2_108000_2000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_105000_8000,o1
-  p2: straight_L3_CSstrip_WNone_N2_105000_5000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_105000_8000,o2
-  p2: straight_L113_CSstrip_WNone_N2_100000_13000,o1
+  p2: straight_L9_CSstrip_WNone_N2_108000_2000_A90,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_105000_8000_A90,o1
+  p2: straight_L3_CSstrip_WNone_N2_105000_5000_A90,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_105000_8000_A90,o2
+  p2: straight_L113_CSstrip_WNone_N2_100000_13000_A180,o1
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_106000_m6000,o1
   p2: straight_L119_CSstrip_WNone_N2_m13000_m6000,o2
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_106000_m6000,o2
-  p2: straight_L15_CSstrip_WNone_N2_111000_m1000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_108000_11000,o1
-  p2: straight_L9_CSstrip_WNone_N2_108000_2000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_108000_11000,o2
-  p2: straight_L119_CSstrip_WNone_N2_103000_16000,o1
+  p2: straight_L15_CSstrip_WNone_N2_111000_m1000_A90,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_108000_11000_A90,o1
+  p2: straight_L9_CSstrip_WNone_N2_108000_2000_A90,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_108000_11000_A90,o2
+  p2: straight_L119_CSstrip_WNone_N2_103000_16000_A180,o1
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_109000_m9000,o1
   p2: straight_L125_CSstrip_WNone_N2_m16000_m9000,o2
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_109000_m9000,o2
-  p2: straight_L21_CSstrip_WNone_N2_114000_m4000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_111000_14000,o1
-  p2: straight_L15_CSstrip_WNone_N2_111000_m1000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_111000_14000,o2
-  p2: straight_L125_CSstrip_WNone_N2_106000_19000,o1
+  p2: straight_L21_CSstrip_WNone_N2_114000_m4000_A90,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_111000_14000_A90,o1
+  p2: straight_L15_CSstrip_WNone_N2_111000_m1000_A90,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_111000_14000_A90,o2
+  p2: straight_L125_CSstrip_WNone_N2_106000_19000_A180,o1
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_112000_m12000,o1
   p2: straight_L131_CSstrip_WNone_N2_m19000_m12000,o2
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_112000_m12000,o2
-  p2: straight_L27_CSstrip_WNone_N2_117000_m7000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_114000_17000,o1
-  p2: straight_L21_CSstrip_WNone_N2_114000_m4000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_114000_17000,o2
-  p2: straight_L131_CSstrip_WNone_N2_109000_22000,o1
+  p2: straight_L27_CSstrip_WNone_N2_117000_m7000_A90,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_114000_17000_A90,o1
+  p2: straight_L21_CSstrip_WNone_N2_114000_m4000_A90,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_114000_17000_A90,o2
+  p2: straight_L131_CSstrip_WNone_N2_109000_22000_A180,o1
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_115000_m15000,o1
   p2: straight_L137_CSstrip_WNone_N2_m22000_m15000,o2
 - p1: bend_euler_RNone_A90_P0_fbfa4d8c_115000_m15000,o2
-  p2: straight_L33_CSstrip_WNone_N2_120000_m10000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_117000_20000,o1
-  p2: straight_L27_CSstrip_WNone_N2_117000_m7000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_117000_20000,o2
-  p2: straight_L137_CSstrip_WNone_N2_112000_25000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_120000_23000,o1
-  p2: straight_L33_CSstrip_WNone_N2_120000_m10000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_120000_23000,o2
-  p2: straight_L143_CSstrip_WNone_N2_115000_28000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m10000_10000,o1
-  p2: bend_euler_RNone_A90_P0_fbfa4d8c_m5000_5000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m10000_10000,o2
-  p2: straight_L3_CSstrip_WNone_N2_m15000_5000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m13000_13000,o1
-  p2: straight_L113_CSstrip_WNone_N2_100000_13000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m13000_13000,o2
-  p2: straight_L9_CSstrip_WNone_N2_m18000_8000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m15000_2000,o1
-  p2: straight_L3_CSstrip_WNone_N2_m15000_5000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m15000_2000,o2
+  p2: straight_L33_CSstrip_WNone_N2_120000_m10000_A90,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_117000_20000_A90,o1
+  p2: straight_L27_CSstrip_WNone_N2_117000_m7000_A90,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_117000_20000_A90,o2
+  p2: straight_L137_CSstrip_WNone_N2_112000_25000_A180,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_120000_23000_A90,o1
+  p2: straight_L33_CSstrip_WNone_N2_120000_m10000_A90,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_120000_23000_A90,o2
+  p2: straight_L143_CSstrip_WNone_N2_115000_28000_A180,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m10000_10000_A180,o1
+  p2: bend_euler_RNone_A90_P0_fbfa4d8c_m5000_5000_A90,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m10000_10000_A180,o2
+  p2: straight_L3_CSstrip_WNone_N2_m15000_5000_A270,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m13000_13000_A180,o1
+  p2: straight_L113_CSstrip_WNone_N2_100000_13000_A180,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m13000_13000_A180,o2
+  p2: straight_L9_CSstrip_WNone_N2_m18000_8000_A270,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m15000_2000_A270,o1
+  p2: straight_L3_CSstrip_WNone_N2_m15000_5000_A270,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m15000_2000_A270,o2
   p2: straight_L113_CSstrip_WNone_N2_m10000_m3000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m16000_16000,o1
-  p2: straight_L119_CSstrip_WNone_N2_103000_16000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m16000_16000,o2
-  p2: straight_L15_CSstrip_WNone_N2_m21000_11000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m18000_m1000,o1
-  p2: straight_L9_CSstrip_WNone_N2_m18000_8000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m18000_m1000,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m16000_16000_A180,o1
+  p2: straight_L119_CSstrip_WNone_N2_103000_16000_A180,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m16000_16000_A180,o2
+  p2: straight_L15_CSstrip_WNone_N2_m21000_11000_A270,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m18000_m1000_A270,o1
+  p2: straight_L9_CSstrip_WNone_N2_m18000_8000_A270,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m18000_m1000_A270,o2
   p2: straight_L119_CSstrip_WNone_N2_m13000_m6000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m19000_19000,o1
-  p2: straight_L125_CSstrip_WNone_N2_106000_19000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m19000_19000,o2
-  p2: straight_L21_CSstrip_WNone_N2_m24000_14000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m21000_m4000,o1
-  p2: straight_L15_CSstrip_WNone_N2_m21000_11000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m21000_m4000,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m19000_19000_A180,o1
+  p2: straight_L125_CSstrip_WNone_N2_106000_19000_A180,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m19000_19000_A180,o2
+  p2: straight_L21_CSstrip_WNone_N2_m24000_14000_A270,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m21000_m4000_A270,o1
+  p2: straight_L15_CSstrip_WNone_N2_m21000_11000_A270,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m21000_m4000_A270,o2
   p2: straight_L125_CSstrip_WNone_N2_m16000_m9000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m22000_22000,o1
-  p2: straight_L131_CSstrip_WNone_N2_109000_22000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m22000_22000,o2
-  p2: straight_L27_CSstrip_WNone_N2_m27000_17000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m24000_m7000,o1
-  p2: straight_L21_CSstrip_WNone_N2_m24000_14000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m24000_m7000,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m22000_22000_A180,o1
+  p2: straight_L131_CSstrip_WNone_N2_109000_22000_A180,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m22000_22000_A180,o2
+  p2: straight_L27_CSstrip_WNone_N2_m27000_17000_A270,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m24000_m7000_A270,o1
+  p2: straight_L21_CSstrip_WNone_N2_m24000_14000_A270,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m24000_m7000_A270,o2
   p2: straight_L131_CSstrip_WNone_N2_m19000_m12000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m25000_25000,o1
-  p2: straight_L137_CSstrip_WNone_N2_112000_25000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m25000_25000,o2
-  p2: straight_L33_CSstrip_WNone_N2_m30000_20000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m27000_m10000,o1
-  p2: straight_L27_CSstrip_WNone_N2_m27000_17000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m27000_m10000,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m25000_25000_A180,o1
+  p2: straight_L137_CSstrip_WNone_N2_112000_25000_A180,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m25000_25000_A180,o2
+  p2: straight_L33_CSstrip_WNone_N2_m30000_20000_A270,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m27000_m10000_A270,o1
+  p2: straight_L27_CSstrip_WNone_N2_m27000_17000_A270,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m27000_m10000_A270,o2
   p2: straight_L137_CSstrip_WNone_N2_m22000_m15000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m28000_28000,o1
-  p2: straight_L143_CSstrip_WNone_N2_115000_28000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m28000_28000,o2
-  p2: straight_L39_CSstrip_WNone_N2_m33000_23000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m30000_m13000,o1
-  p2: straight_L33_CSstrip_WNone_N2_m30000_20000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m30000_m13000,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m28000_28000_A180,o1
+  p2: straight_L143_CSstrip_WNone_N2_115000_28000_A180,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m28000_28000_A180,o2
+  p2: straight_L39_CSstrip_WNone_N2_m33000_23000_A270,o1
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m30000_m13000_A270,o1
+  p2: straight_L33_CSstrip_WNone_N2_m30000_20000_A270,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m30000_m13000_A270,o2
   p2: straight_L143_CSstrip_WNone_N2_m25000_m18000,o1
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m33000_m16000,o1
-  p2: straight_L39_CSstrip_WNone_N2_m33000_23000,o2
-- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m33000_m16000,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m33000_m16000_A270,o1
+  p2: straight_L39_CSstrip_WNone_N2_m33000_23000_A270,o2
+- p1: bend_euler_RNone_A90_P0_fbfa4d8c_m33000_m16000_A270,o2
   p2: straight_L149_CSstrip_WNone_N2_m28000_m21000,o1
 placements:
-  bend_euler_RNone_A90_P0_fbfa4d8c_0_0:
+  bend_euler_RNone_A90_P0_fbfa4d8c_0_0_A180_M:
     mirror: true
     rotation: 180
     x: 0
@@ -1091,7 +1091,7 @@ placements:
     rotation: 0
     x: 103
     y: -3
-  bend_euler_RNone_A90_P0_fbfa4d8c_105000_8000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_105000_8000_A90:
     mirror: false
     rotation: 90
     x: 105
@@ -1101,7 +1101,7 @@ placements:
     rotation: 0
     x: 106
     y: -6
-  bend_euler_RNone_A90_P0_fbfa4d8c_108000_11000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_108000_11000_A90:
     mirror: false
     rotation: 90
     x: 108
@@ -1111,7 +1111,7 @@ placements:
     rotation: 0
     x: 109
     y: -9
-  bend_euler_RNone_A90_P0_fbfa4d8c_111000_14000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_111000_14000_A90:
     mirror: false
     rotation: 90
     x: 111
@@ -1121,7 +1121,7 @@ placements:
     rotation: 0
     x: 112
     y: -12
-  bend_euler_RNone_A90_P0_fbfa4d8c_114000_17000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_114000_17000_A90:
     mirror: false
     rotation: 90
     x: 114
@@ -1131,87 +1131,87 @@ placements:
     rotation: 0
     x: 115
     y: -15
-  bend_euler_RNone_A90_P0_fbfa4d8c_117000_20000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_117000_20000_A90:
     mirror: false
     rotation: 90
     x: 117
     y: 20
-  bend_euler_RNone_A90_P0_fbfa4d8c_120000_23000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_120000_23000_A90:
     mirror: false
     rotation: 90
     x: 120
     y: 23
-  bend_euler_RNone_A90_P0_fbfa4d8c_m10000_10000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m10000_10000_A180:
     mirror: false
     rotation: 180
     x: -10
     y: 10
-  bend_euler_RNone_A90_P0_fbfa4d8c_m13000_13000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m13000_13000_A180:
     mirror: false
     rotation: 180
     x: -13
     y: 13
-  bend_euler_RNone_A90_P0_fbfa4d8c_m15000_2000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m15000_2000_A270:
     mirror: false
     rotation: 270
     x: -15
     y: 2
-  bend_euler_RNone_A90_P0_fbfa4d8c_m16000_16000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m16000_16000_A180:
     mirror: false
     rotation: 180
     x: -16
     y: 16
-  bend_euler_RNone_A90_P0_fbfa4d8c_m18000_m1000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m18000_m1000_A270:
     mirror: false
     rotation: 270
     x: -18
     y: -1
-  bend_euler_RNone_A90_P0_fbfa4d8c_m19000_19000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m19000_19000_A180:
     mirror: false
     rotation: 180
     x: -19
     y: 19
-  bend_euler_RNone_A90_P0_fbfa4d8c_m21000_m4000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m21000_m4000_A270:
     mirror: false
     rotation: 270
     x: -21
     y: -4
-  bend_euler_RNone_A90_P0_fbfa4d8c_m22000_22000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m22000_22000_A180:
     mirror: false
     rotation: 180
     x: -22
     y: 22
-  bend_euler_RNone_A90_P0_fbfa4d8c_m24000_m7000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m24000_m7000_A270:
     mirror: false
     rotation: 270
     x: -24
     y: -7
-  bend_euler_RNone_A90_P0_fbfa4d8c_m25000_25000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m25000_25000_A180:
     mirror: false
     rotation: 180
     x: -25
     y: 25
-  bend_euler_RNone_A90_P0_fbfa4d8c_m27000_m10000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m27000_m10000_A270:
     mirror: false
     rotation: 270
     x: -27
     y: -10
-  bend_euler_RNone_A90_P0_fbfa4d8c_m28000_28000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m28000_28000_A180:
     mirror: false
     rotation: 180
     x: -28
     y: 28
-  bend_euler_RNone_A90_P0_fbfa4d8c_m30000_m13000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m30000_m13000_A270:
     mirror: false
     rotation: 270
     x: -30
     y: -13
-  bend_euler_RNone_A90_P0_fbfa4d8c_m33000_m16000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m33000_m16000_A270:
     mirror: false
     rotation: 270
     x: -33
     y: -16
-  bend_euler_RNone_A90_P0_fbfa4d8c_m5000_5000:
+  bend_euler_RNone_A90_P0_fbfa4d8c_m5000_5000_A90:
     mirror: false
     rotation: 90
     x: -5
@@ -1221,7 +1221,7 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_L113_CSstrip_WNone_N2_100000_13000:
+  straight_L113_CSstrip_WNone_N2_100000_13000_A180:
     mirror: false
     rotation: 180
     x: 100
@@ -1231,7 +1231,7 @@ placements:
     rotation: 0
     x: -10
     y: -3
-  straight_L119_CSstrip_WNone_N2_103000_16000:
+  straight_L119_CSstrip_WNone_N2_103000_16000_A180:
     mirror: false
     rotation: 180
     x: 103
@@ -1241,7 +1241,7 @@ placements:
     rotation: 0
     x: -13
     y: -6
-  straight_L125_CSstrip_WNone_N2_106000_19000:
+  straight_L125_CSstrip_WNone_N2_106000_19000_A180:
     mirror: false
     rotation: 180
     x: 106
@@ -1251,7 +1251,7 @@ placements:
     rotation: 0
     x: -16
     y: -9
-  straight_L131_CSstrip_WNone_N2_109000_22000:
+  straight_L131_CSstrip_WNone_N2_109000_22000_A180:
     mirror: false
     rotation: 180
     x: 109
@@ -1261,7 +1261,7 @@ placements:
     rotation: 0
     x: -19
     y: -12
-  straight_L137_CSstrip_WNone_N2_112000_25000:
+  straight_L137_CSstrip_WNone_N2_112000_25000_A180:
     mirror: false
     rotation: 180
     x: 112
@@ -1271,7 +1271,7 @@ placements:
     rotation: 0
     x: -22
     y: -15
-  straight_L143_CSstrip_WNone_N2_115000_28000:
+  straight_L143_CSstrip_WNone_N2_115000_28000_A180:
     mirror: false
     rotation: 180
     x: 115
@@ -1286,67 +1286,67 @@ placements:
     rotation: 0
     x: -28
     y: -21
-  straight_L15_CSstrip_WNone_N2_111000_m1000:
+  straight_L15_CSstrip_WNone_N2_111000_m1000_A90:
     mirror: false
     rotation: 90
     x: 111
     y: -1
-  straight_L15_CSstrip_WNone_N2_m21000_11000:
+  straight_L15_CSstrip_WNone_N2_m21000_11000_A270:
     mirror: false
     rotation: 270
     x: -21
     y: 11
-  straight_L21_CSstrip_WNone_N2_114000_m4000:
+  straight_L21_CSstrip_WNone_N2_114000_m4000_A90:
     mirror: false
     rotation: 90
     x: 114
     y: -4
-  straight_L21_CSstrip_WNone_N2_m24000_14000:
+  straight_L21_CSstrip_WNone_N2_m24000_14000_A270:
     mirror: false
     rotation: 270
     x: -24
     y: 14
-  straight_L27_CSstrip_WNone_N2_117000_m7000:
+  straight_L27_CSstrip_WNone_N2_117000_m7000_A90:
     mirror: false
     rotation: 90
     x: 117
     y: -7
-  straight_L27_CSstrip_WNone_N2_m27000_17000:
+  straight_L27_CSstrip_WNone_N2_m27000_17000_A270:
     mirror: false
     rotation: 270
     x: -27
     y: 17
-  straight_L33_CSstrip_WNone_N2_120000_m10000:
+  straight_L33_CSstrip_WNone_N2_120000_m10000_A90:
     mirror: false
     rotation: 90
     x: 120
     y: -10
-  straight_L33_CSstrip_WNone_N2_m30000_20000:
+  straight_L33_CSstrip_WNone_N2_m30000_20000_A270:
     mirror: false
     rotation: 270
     x: -30
     y: 20
-  straight_L39_CSstrip_WNone_N2_m33000_23000:
+  straight_L39_CSstrip_WNone_N2_m33000_23000_A270:
     mirror: false
     rotation: 270
     x: -33
     y: 23
-  straight_L3_CSstrip_WNone_N2_105000_5000:
+  straight_L3_CSstrip_WNone_N2_105000_5000_A90:
     mirror: false
     rotation: 90
     x: 105
     y: 5
-  straight_L3_CSstrip_WNone_N2_m15000_5000:
+  straight_L3_CSstrip_WNone_N2_m15000_5000_A270:
     mirror: false
     rotation: 270
     x: -15
     y: 5
-  straight_L9_CSstrip_WNone_N2_108000_2000:
+  straight_L9_CSstrip_WNone_N2_108000_2000_A90:
     mirror: false
     rotation: 90
     x: 108
     y: 2
-  straight_L9_CSstrip_WNone_N2_m18000_8000:
+  straight_L9_CSstrip_WNone_N2_m18000_8000_A270:
     mirror: false
     rotation: 270
     x: -18

--- a/tests/test_si220_cband/test_netlists_spiral_racetrack_.yml
+++ b/tests/test_si220_cband/test_netlists_spiral_racetrack_.yml
@@ -1,5 +1,5 @@
 instances:
-  bend_euler_R12_A180_P0p_834d3699_0_6000:
+  bend_euler_R12_A180_P0p_834d3699_0_6000_A180:
     component: bend_euler
     info:
       dy: 0
@@ -41,7 +41,7 @@ instances:
       p: 0.5
       radius: 12
       width: null
-  bend_euler_R15_A180_P0p_16968374_0_10000:
+  bend_euler_R15_A180_P0p_16968374_0_10000_A180:
     component: bend_euler
     info:
       dy: 0
@@ -83,7 +83,7 @@ instances:
       p: 0.5
       radius: 15
       width: null
-  bend_euler_R17_A180_P0p_8af989a6_0_12000:
+  bend_euler_R17_A180_P0p_8af989a6_0_12000_A180:
     component: bend_euler
     info:
       dy: 0
@@ -125,7 +125,7 @@ instances:
       p: 0.5
       radius: 17
       width: null
-  bend_euler_R5_A180_P0p5_224e2057_0_0:
+  bend_euler_R5_A180_P0p5_224e2057_0_0_A180:
     component: bend_euler
     info:
       dy: 0
@@ -167,7 +167,7 @@ instances:
       p: 0.5
       radius: 5
       width: null
-  bend_euler_R7_A180_P0p5_7d8495e9_0_2000:
+  bend_euler_R7_A180_P0p5_7d8495e9_0_2000_A180:
     component: bend_euler
     info:
       dy: 0
@@ -209,7 +209,7 @@ instances:
       p: 0.5
       radius: 7
       width: null
-  bend_euler_R9_A180_P0p5_431cc5ca_0_4000:
+  bend_euler_R9_A180_P0p5_431cc5ca_0_4000_A180:
     component: bend_euler
     info:
       dy: 0
@@ -355,7 +355,7 @@ instances:
       length: 20
       npoints: 2
       width: null
-  straight_L20_CSstrip_WNone_N2_20000_10000:
+  straight_L20_CSstrip_WNone_N2_20000_10000_A180:
     component: straight
     info:
       length: 20
@@ -369,7 +369,7 @@ instances:
       length: 20
       npoints: 2
       width: null
-  straight_L20_CSstrip_WNone_N2_20000_12000:
+  straight_L20_CSstrip_WNone_N2_20000_12000_A180:
     component: straight
     info:
       length: 20
@@ -383,7 +383,7 @@ instances:
       length: 20
       npoints: 2
       width: null
-  straight_L20_CSstrip_WNone_N2_20000_14000:
+  straight_L20_CSstrip_WNone_N2_20000_14000_A180:
     component: straight
     info:
       length: 20
@@ -397,7 +397,7 @@ instances:
       length: 20
       npoints: 2
       width: null
-  straight_L20_CSstrip_WNone_N2_20000_2000:
+  straight_L20_CSstrip_WNone_N2_20000_2000_A180:
     component: straight
     info:
       length: 20
@@ -411,7 +411,7 @@ instances:
       length: 20
       npoints: 2
       width: null
-  straight_L20_CSstrip_WNone_N2_20000_4000:
+  straight_L20_CSstrip_WNone_N2_20000_4000_A180:
     component: straight
     info:
       length: 20
@@ -425,7 +425,7 @@ instances:
       length: 20
       npoints: 2
       width: null
-  straight_L20_CSstrip_WNone_N2_20000_6000:
+  straight_L20_CSstrip_WNone_N2_20000_6000_A180:
     component: straight
     info:
       length: 20
@@ -441,56 +441,56 @@ instances:
       width: null
 name: spiral_racetrack_MRNone_05d4c3d3
 nets:
-- p1: bend_euler_R12_A180_P0p_834d3699_0_6000,o1
-  p2: straight_L20_CSstrip_WNone_N2_20000_6000,o2
-- p1: bend_euler_R12_A180_P0p_834d3699_0_6000,o2
+- p1: bend_euler_R12_A180_P0p_834d3699_0_6000_A180,o1
+  p2: straight_L20_CSstrip_WNone_N2_20000_6000_A180,o2
+- p1: bend_euler_R12_A180_P0p_834d3699_0_6000_A180,o2
   p2: straight_L20_CSstrip_WNone_N2_0_m18000,o1
 - p1: bend_euler_R12_A180_P0p_834d3699_20000_m14000,o1
   p2: straight_L20_CSstrip_WNone_N2_0_m14000,o2
 - p1: bend_euler_R12_A180_P0p_834d3699_20000_m14000,o2
-  p2: straight_L20_CSstrip_WNone_N2_20000_10000,o1
-- p1: bend_euler_R15_A180_P0p_16968374_0_10000,o1
-  p2: straight_L20_CSstrip_WNone_N2_20000_10000,o2
-- p1: bend_euler_R15_A180_P0p_16968374_0_10000,o2
+  p2: straight_L20_CSstrip_WNone_N2_20000_10000_A180,o1
+- p1: bend_euler_R15_A180_P0p_16968374_0_10000_A180,o1
+  p2: straight_L20_CSstrip_WNone_N2_20000_10000_A180,o2
+- p1: bend_euler_R15_A180_P0p_16968374_0_10000_A180,o2
   p2: straight_L20_CSstrip_WNone_N2_0_m20000,o1
 - p1: bend_euler_R15_A180_P0p_16968374_20000_m18000,o1
   p2: straight_L20_CSstrip_WNone_N2_0_m18000,o2
 - p1: bend_euler_R15_A180_P0p_16968374_20000_m18000,o2
-  p2: straight_L20_CSstrip_WNone_N2_20000_12000,o1
-- p1: bend_euler_R17_A180_P0p_8af989a6_0_12000,o1
-  p2: straight_L20_CSstrip_WNone_N2_20000_12000,o2
-- p1: bend_euler_R17_A180_P0p_8af989a6_0_12000,o2
+  p2: straight_L20_CSstrip_WNone_N2_20000_12000_A180,o1
+- p1: bend_euler_R17_A180_P0p_8af989a6_0_12000_A180,o1
+  p2: straight_L20_CSstrip_WNone_N2_20000_12000_A180,o2
+- p1: bend_euler_R17_A180_P0p_8af989a6_0_12000_A180,o2
   p2: straight_L20_CSstrip_WNone_N2_0_m22000,o1
 - p1: bend_euler_R17_A180_P0p_8af989a6_20000_m20000,o1
   p2: straight_L20_CSstrip_WNone_N2_0_m20000,o2
 - p1: bend_euler_R17_A180_P0p_8af989a6_20000_m20000,o2
-  p2: straight_L20_CSstrip_WNone_N2_20000_14000,o1
-- p1: bend_euler_R5_A180_P0p5_224e2057_0_0,o1
+  p2: straight_L20_CSstrip_WNone_N2_20000_14000_A180,o1
+- p1: bend_euler_R5_A180_P0p5_224e2057_0_0_A180,o1
   p2: bend_s_S20_m8_CSstrip_W_198c7a61_0_0,o1
-- p1: bend_euler_R5_A180_P0p5_224e2057_0_0,o2
+- p1: bend_euler_R5_A180_P0p5_224e2057_0_0_A180,o2
   p2: straight_L20_CSstrip_WNone_N2_0_m10000,o1
 - p1: bend_euler_R5_A180_P0p5_224e2057_20000_m8000,o1
   p2: bend_s_S20_m8_CSstrip_W_198c7a61_0_0,o2
 - p1: bend_euler_R5_A180_P0p5_224e2057_20000_m8000,o2
-  p2: straight_L20_CSstrip_WNone_N2_20000_2000,o1
-- p1: bend_euler_R7_A180_P0p5_7d8495e9_0_2000,o1
-  p2: straight_L20_CSstrip_WNone_N2_20000_2000,o2
-- p1: bend_euler_R7_A180_P0p5_7d8495e9_0_2000,o2
+  p2: straight_L20_CSstrip_WNone_N2_20000_2000_A180,o1
+- p1: bend_euler_R7_A180_P0p5_7d8495e9_0_2000_A180,o1
+  p2: straight_L20_CSstrip_WNone_N2_20000_2000_A180,o2
+- p1: bend_euler_R7_A180_P0p5_7d8495e9_0_2000_A180,o2
   p2: straight_L20_CSstrip_WNone_N2_0_m12000,o1
 - p1: bend_euler_R7_A180_P0p5_7d8495e9_20000_m10000,o1
   p2: straight_L20_CSstrip_WNone_N2_0_m10000,o2
 - p1: bend_euler_R7_A180_P0p5_7d8495e9_20000_m10000,o2
-  p2: straight_L20_CSstrip_WNone_N2_20000_4000,o1
-- p1: bend_euler_R9_A180_P0p5_431cc5ca_0_4000,o1
-  p2: straight_L20_CSstrip_WNone_N2_20000_4000,o2
-- p1: bend_euler_R9_A180_P0p5_431cc5ca_0_4000,o2
+  p2: straight_L20_CSstrip_WNone_N2_20000_4000_A180,o1
+- p1: bend_euler_R9_A180_P0p5_431cc5ca_0_4000_A180,o1
+  p2: straight_L20_CSstrip_WNone_N2_20000_4000_A180,o2
+- p1: bend_euler_R9_A180_P0p5_431cc5ca_0_4000_A180,o2
   p2: straight_L20_CSstrip_WNone_N2_0_m14000,o1
 - p1: bend_euler_R9_A180_P0p5_431cc5ca_20000_m12000,o1
   p2: straight_L20_CSstrip_WNone_N2_0_m12000,o2
 - p1: bend_euler_R9_A180_P0p5_431cc5ca_20000_m12000,o2
-  p2: straight_L20_CSstrip_WNone_N2_20000_6000,o1
+  p2: straight_L20_CSstrip_WNone_N2_20000_6000_A180,o1
 placements:
-  bend_euler_R12_A180_P0p_834d3699_0_6000:
+  bend_euler_R12_A180_P0p_834d3699_0_6000_A180:
     mirror: false
     rotation: 180
     x: 0
@@ -500,7 +500,7 @@ placements:
     rotation: 0
     x: 20
     y: -14
-  bend_euler_R15_A180_P0p_16968374_0_10000:
+  bend_euler_R15_A180_P0p_16968374_0_10000_A180:
     mirror: false
     rotation: 180
     x: 0
@@ -510,7 +510,7 @@ placements:
     rotation: 0
     x: 20
     y: -18
-  bend_euler_R17_A180_P0p_8af989a6_0_12000:
+  bend_euler_R17_A180_P0p_8af989a6_0_12000_A180:
     mirror: false
     rotation: 180
     x: 0
@@ -520,7 +520,7 @@ placements:
     rotation: 0
     x: 20
     y: -20
-  bend_euler_R5_A180_P0p5_224e2057_0_0:
+  bend_euler_R5_A180_P0p5_224e2057_0_0_A180:
     mirror: false
     rotation: 180
     x: 0
@@ -530,7 +530,7 @@ placements:
     rotation: 0
     x: 20
     y: -8
-  bend_euler_R7_A180_P0p5_7d8495e9_0_2000:
+  bend_euler_R7_A180_P0p5_7d8495e9_0_2000_A180:
     mirror: false
     rotation: 180
     x: 0
@@ -540,7 +540,7 @@ placements:
     rotation: 0
     x: 20
     y: -10
-  bend_euler_R9_A180_P0p5_431cc5ca_0_4000:
+  bend_euler_R9_A180_P0p5_431cc5ca_0_4000_A180:
     mirror: false
     rotation: 180
     x: 0
@@ -585,36 +585,36 @@ placements:
     rotation: 0
     x: 0
     y: -22
-  straight_L20_CSstrip_WNone_N2_20000_10000:
+  straight_L20_CSstrip_WNone_N2_20000_10000_A180:
     mirror: false
     rotation: 180
     x: 20
     y: 10
-  straight_L20_CSstrip_WNone_N2_20000_12000:
+  straight_L20_CSstrip_WNone_N2_20000_12000_A180:
     mirror: false
     rotation: 180
     x: 20
     y: 12
-  straight_L20_CSstrip_WNone_N2_20000_14000:
+  straight_L20_CSstrip_WNone_N2_20000_14000_A180:
     mirror: false
     rotation: 180
     x: 20
     y: 14
-  straight_L20_CSstrip_WNone_N2_20000_2000:
+  straight_L20_CSstrip_WNone_N2_20000_2000_A180:
     mirror: false
     rotation: 180
     x: 20
     y: 2
-  straight_L20_CSstrip_WNone_N2_20000_4000:
+  straight_L20_CSstrip_WNone_N2_20000_4000_A180:
     mirror: false
     rotation: 180
     x: 20
     y: 4
-  straight_L20_CSstrip_WNone_N2_20000_6000:
+  straight_L20_CSstrip_WNone_N2_20000_6000_A180:
     mirror: false
     rotation: 180
     x: 20
     y: 6
 ports:
-  o1: straight_L20_CSstrip_WNone_N2_20000_14000,o2
+  o1: straight_L20_CSstrip_WNone_N2_20000_14000_A180,o2
   o2: straight_L20_CSstrip_WNone_N2_0_m22000,o2

--- a/tests/test_si220_cband/test_netlists_spiral_racetrack_heater_.yml
+++ b/tests/test_si220_cband/test_netlists_spiral_racetrack_heater_.yml
@@ -43,7 +43,7 @@ instances:
       - 4
       straight: straight
       straight_length: 100
-  straight_gdsfactorypcom_262b2f90_54277_22000:
+  straight_gdsfactorypcom_262b2f90_54277_22000_A180:
     component: straight
     info:
       length: 100
@@ -57,7 +57,7 @@ instances:
       length: 100
       npoints: 2
       width: null
-  straight_gdsfactorypcom_262b2f90_54277_m28000:
+  straight_gdsfactorypcom_262b2f90_54277_m28000_A180:
     component: straight
     info:
       length: 100
@@ -92,12 +92,12 @@ instances:
 name: spiral_racetrack_heater_8f268b5e
 nets:
 - p1: bend_euler_R25_A180_P0p_ce329588_54277_m28000,e1
-  p2: straight_gdsfactorypcom_262b2f90_54277_m28000,e1
+  p2: straight_gdsfactorypcom_262b2f90_54277_m28000_A180,e1
 - p1: bend_euler_R25_A180_P0p_ce329588_54277_m28000,e2
-  p2: straight_gdsfactorypcom_262b2f90_54277_22000,e1
-- p1: straight_gdsfactorypcom_262b2f90_54277_22000,e2
+  p2: straight_gdsfactorypcom_262b2f90_54277_22000_A180,e1
+- p1: straight_gdsfactorypcom_262b2f90_54277_22000_A180,e2
   p2: via_stack_heater_mtop_S20_10_m55723_22000,e3
-- p1: straight_gdsfactorypcom_262b2f90_54277_m28000,e2
+- p1: straight_gdsfactorypcom_262b2f90_54277_m28000_A180,e2
   p2: via_stack_heater_mtop_S20_10_m55723_m28000,e3
 placements:
   bend_euler_R25_A180_P0p_ce329588_54277_m28000:
@@ -110,12 +110,12 @@ placements:
     rotation: 0
     x: 0
     y: 0
-  straight_gdsfactorypcom_262b2f90_54277_22000:
+  straight_gdsfactorypcom_262b2f90_54277_22000_A180:
     mirror: false
     rotation: 180
     x: 54.277
     y: 22
-  straight_gdsfactorypcom_262b2f90_54277_m28000:
+  straight_gdsfactorypcom_262b2f90_54277_m28000_A180:
     mirror: false
     rotation: 180
     x: 54.277

--- a/tests/test_si220_cband/test_settings_coupler_.yml
+++ b/tests/test_si220_cband/test_settings_coupler_.yml
@@ -1,6 +1,6 @@
 info:
-  length: 10.188
   min_bend_radius: 11.807
+  path_length: 40.376
 name: coupler_L20_G0p27
 settings:
   gap: 0.27

--- a/tests/test_si220_cband/test_settings_coupler_rib_.yml
+++ b/tests/test_si220_cband/test_settings_coupler_rib_.yml
@@ -1,6 +1,6 @@
 info:
-  length: 16.083
   min_bend_radius: 34.638
+  path_length: 52.166
 name: coupler_rib_L20_G0p27
 settings:
   gap: 0.27

--- a/tests/test_si500.py
+++ b/tests/test_si500.py
@@ -20,7 +20,7 @@ def activate_pdk() -> None:
 
 
 cells = PDK.cells
-skip_test = {"coupler_symmetric"}
+skip_test = {"coupler_symmetric", "die", "die_rc", "die_ro"}
 cell_names = cells.keys() - skip_test
 cell_names = [name for name in cell_names if not name.startswith("_")]
 dirpath = pathlib.Path(__file__).absolute().with_suffix(".gds").parent / "gds_ref_si500"

--- a/tests/test_si500/test_netlists_die_.yml
+++ b/tests/test_si500/test_netlists_die_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_9da66307_5145575_0:
+  grating_coupler_array_g_ca7315b3_5145575_0_A90:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_rc
       grating_coupler: grating_coupler_rectangular_rc
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_9da66307_m5145575_0:
+  grating_coupler_array_g_ca7315b3_m5145575_0_A270:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_rc
       grating_coupler: grating_coupler_rectangular_rc
@@ -603,12 +605,12 @@ instances:
 name: die_CSxs_rc
 nets: []
 placements:
-  grating_coupler_array_g_9da66307_5145575_0:
+  grating_coupler_array_g_ca7315b3_5145575_0_A90:
     mirror: false
     rotation: 90
     x: 5145.575
     y: 0
-  grating_coupler_array_g_9da66307_m5145575_0:
+  grating_coupler_array_g_ca7315b3_m5145575_0_A270:
     mirror: false
     rotation: 270
     x: -5145.575
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_9da66307_5145575_0,o1
-  o10: grating_coupler_array_g_9da66307_5145575_0,o10
-  o11: grating_coupler_array_g_9da66307_5145575_0,o11
-  o12: grating_coupler_array_g_9da66307_5145575_0,o12
-  o13: grating_coupler_array_g_9da66307_m5145575_0,o1
-  o14: grating_coupler_array_g_9da66307_m5145575_0,o2
-  o15: grating_coupler_array_g_9da66307_m5145575_0,o3
-  o16: grating_coupler_array_g_9da66307_m5145575_0,o4
-  o17: grating_coupler_array_g_9da66307_m5145575_0,o5
-  o18: grating_coupler_array_g_9da66307_m5145575_0,o6
-  o19: grating_coupler_array_g_9da66307_m5145575_0,o7
-  o2: grating_coupler_array_g_9da66307_5145575_0,o2
-  o20: grating_coupler_array_g_9da66307_m5145575_0,o8
-  o21: grating_coupler_array_g_9da66307_m5145575_0,o9
-  o22: grating_coupler_array_g_9da66307_m5145575_0,o10
-  o23: grating_coupler_array_g_9da66307_m5145575_0,o11
-  o24: grating_coupler_array_g_9da66307_m5145575_0,o12
-  o3: grating_coupler_array_g_9da66307_5145575_0,o3
-  o4: grating_coupler_array_g_9da66307_5145575_0,o4
-  o5: grating_coupler_array_g_9da66307_5145575_0,o5
-  o6: grating_coupler_array_g_9da66307_5145575_0,o6
-  o7: grating_coupler_array_g_9da66307_5145575_0,o7
-  o8: grating_coupler_array_g_9da66307_5145575_0,o8
-  o9: grating_coupler_array_g_9da66307_5145575_0,o9
+  o1: grating_coupler_array_g_ca7315b3_5145575_0_A90,o1
+  o10: grating_coupler_array_g_ca7315b3_5145575_0_A90,o10
+  o11: grating_coupler_array_g_ca7315b3_5145575_0_A90,o11
+  o12: grating_coupler_array_g_ca7315b3_5145575_0_A90,o12
+  o13: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o1
+  o14: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o2
+  o15: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o3
+  o16: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o4
+  o17: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o5
+  o18: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o6
+  o19: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o7
+  o2: grating_coupler_array_g_ca7315b3_5145575_0_A90,o2
+  o20: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o8
+  o21: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o9
+  o22: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o10
+  o23: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o11
+  o24: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o12
+  o3: grating_coupler_array_g_ca7315b3_5145575_0_A90,o3
+  o4: grating_coupler_array_g_ca7315b3_5145575_0_A90,o4
+  o5: grating_coupler_array_g_ca7315b3_5145575_0_A90,o5
+  o6: grating_coupler_array_g_ca7315b3_5145575_0_A90,o6
+  o7: grating_coupler_array_g_ca7315b3_5145575_0_A90,o7
+  o8: grating_coupler_array_g_ca7315b3_5145575_0_A90,o8
+  o9: grating_coupler_array_g_ca7315b3_5145575_0_A90,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test_si500/test_netlists_die_rc_.yml
+++ b/tests/test_si500/test_netlists_die_rc_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_9da66307_5145575_0:
+  grating_coupler_array_g_ca7315b3_5145575_0_A90:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_rc
       grating_coupler: grating_coupler_rectangular_rc
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_9da66307_m5145575_0:
+  grating_coupler_array_g_ca7315b3_m5145575_0_A270:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_rc
       grating_coupler: grating_coupler_rectangular_rc
@@ -603,12 +605,12 @@ instances:
 name: die_CSxs_rc
 nets: []
 placements:
-  grating_coupler_array_g_9da66307_5145575_0:
+  grating_coupler_array_g_ca7315b3_5145575_0_A90:
     mirror: false
     rotation: 90
     x: 5145.575
     y: 0
-  grating_coupler_array_g_9da66307_m5145575_0:
+  grating_coupler_array_g_ca7315b3_m5145575_0_A270:
     mirror: false
     rotation: 270
     x: -5145.575
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_9da66307_5145575_0,o1
-  o10: grating_coupler_array_g_9da66307_5145575_0,o10
-  o11: grating_coupler_array_g_9da66307_5145575_0,o11
-  o12: grating_coupler_array_g_9da66307_5145575_0,o12
-  o13: grating_coupler_array_g_9da66307_m5145575_0,o1
-  o14: grating_coupler_array_g_9da66307_m5145575_0,o2
-  o15: grating_coupler_array_g_9da66307_m5145575_0,o3
-  o16: grating_coupler_array_g_9da66307_m5145575_0,o4
-  o17: grating_coupler_array_g_9da66307_m5145575_0,o5
-  o18: grating_coupler_array_g_9da66307_m5145575_0,o6
-  o19: grating_coupler_array_g_9da66307_m5145575_0,o7
-  o2: grating_coupler_array_g_9da66307_5145575_0,o2
-  o20: grating_coupler_array_g_9da66307_m5145575_0,o8
-  o21: grating_coupler_array_g_9da66307_m5145575_0,o9
-  o22: grating_coupler_array_g_9da66307_m5145575_0,o10
-  o23: grating_coupler_array_g_9da66307_m5145575_0,o11
-  o24: grating_coupler_array_g_9da66307_m5145575_0,o12
-  o3: grating_coupler_array_g_9da66307_5145575_0,o3
-  o4: grating_coupler_array_g_9da66307_5145575_0,o4
-  o5: grating_coupler_array_g_9da66307_5145575_0,o5
-  o6: grating_coupler_array_g_9da66307_5145575_0,o6
-  o7: grating_coupler_array_g_9da66307_5145575_0,o7
-  o8: grating_coupler_array_g_9da66307_5145575_0,o8
-  o9: grating_coupler_array_g_9da66307_5145575_0,o9
+  o1: grating_coupler_array_g_ca7315b3_5145575_0_A90,o1
+  o10: grating_coupler_array_g_ca7315b3_5145575_0_A90,o10
+  o11: grating_coupler_array_g_ca7315b3_5145575_0_A90,o11
+  o12: grating_coupler_array_g_ca7315b3_5145575_0_A90,o12
+  o13: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o1
+  o14: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o2
+  o15: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o3
+  o16: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o4
+  o17: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o5
+  o18: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o6
+  o19: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o7
+  o2: grating_coupler_array_g_ca7315b3_5145575_0_A90,o2
+  o20: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o8
+  o21: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o9
+  o22: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o10
+  o23: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o11
+  o24: grating_coupler_array_g_ca7315b3_m5145575_0_A270,o12
+  o3: grating_coupler_array_g_ca7315b3_5145575_0_A90,o3
+  o4: grating_coupler_array_g_ca7315b3_5145575_0_A90,o4
+  o5: grating_coupler_array_g_ca7315b3_5145575_0_A90,o5
+  o6: grating_coupler_array_g_ca7315b3_5145575_0_A90,o6
+  o7: grating_coupler_array_g_ca7315b3_5145575_0_A90,o7
+  o8: grating_coupler_array_g_ca7315b3_5145575_0_A90,o8
+  o9: grating_coupler_array_g_ca7315b3_5145575_0_A90,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test_si500/test_netlists_die_ro_.yml
+++ b/tests/test_si500/test_netlists_die_ro_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_043784bb_5145600_0:
+  grating_coupler_array_g_88d492f7_5145600_0_A90:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_ro
       grating_coupler: grating_coupler_rectangular_ro
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_043784bb_m5145600_0:
+  grating_coupler_array_g_88d492f7_m5145600_0_A270:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_ro
       grating_coupler: grating_coupler_rectangular_ro
@@ -603,12 +605,12 @@ instances:
 name: die_CSxs_ro
 nets: []
 placements:
-  grating_coupler_array_g_043784bb_5145600_0:
+  grating_coupler_array_g_88d492f7_5145600_0_A90:
     mirror: false
     rotation: 90
     x: 5145.6
     y: 0
-  grating_coupler_array_g_043784bb_m5145600_0:
+  grating_coupler_array_g_88d492f7_m5145600_0_A270:
     mirror: false
     rotation: 270
     x: -5145.6
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_043784bb_5145600_0,o1
-  o10: grating_coupler_array_g_043784bb_5145600_0,o10
-  o11: grating_coupler_array_g_043784bb_5145600_0,o11
-  o12: grating_coupler_array_g_043784bb_5145600_0,o12
-  o13: grating_coupler_array_g_043784bb_m5145600_0,o1
-  o14: grating_coupler_array_g_043784bb_m5145600_0,o2
-  o15: grating_coupler_array_g_043784bb_m5145600_0,o3
-  o16: grating_coupler_array_g_043784bb_m5145600_0,o4
-  o17: grating_coupler_array_g_043784bb_m5145600_0,o5
-  o18: grating_coupler_array_g_043784bb_m5145600_0,o6
-  o19: grating_coupler_array_g_043784bb_m5145600_0,o7
-  o2: grating_coupler_array_g_043784bb_5145600_0,o2
-  o20: grating_coupler_array_g_043784bb_m5145600_0,o8
-  o21: grating_coupler_array_g_043784bb_m5145600_0,o9
-  o22: grating_coupler_array_g_043784bb_m5145600_0,o10
-  o23: grating_coupler_array_g_043784bb_m5145600_0,o11
-  o24: grating_coupler_array_g_043784bb_m5145600_0,o12
-  o3: grating_coupler_array_g_043784bb_5145600_0,o3
-  o4: grating_coupler_array_g_043784bb_5145600_0,o4
-  o5: grating_coupler_array_g_043784bb_5145600_0,o5
-  o6: grating_coupler_array_g_043784bb_5145600_0,o6
-  o7: grating_coupler_array_g_043784bb_5145600_0,o7
-  o8: grating_coupler_array_g_043784bb_5145600_0,o8
-  o9: grating_coupler_array_g_043784bb_5145600_0,o9
+  o1: grating_coupler_array_g_88d492f7_5145600_0_A90,o1
+  o10: grating_coupler_array_g_88d492f7_5145600_0_A90,o10
+  o11: grating_coupler_array_g_88d492f7_5145600_0_A90,o11
+  o12: grating_coupler_array_g_88d492f7_5145600_0_A90,o12
+  o13: grating_coupler_array_g_88d492f7_m5145600_0_A270,o1
+  o14: grating_coupler_array_g_88d492f7_m5145600_0_A270,o2
+  o15: grating_coupler_array_g_88d492f7_m5145600_0_A270,o3
+  o16: grating_coupler_array_g_88d492f7_m5145600_0_A270,o4
+  o17: grating_coupler_array_g_88d492f7_m5145600_0_A270,o5
+  o18: grating_coupler_array_g_88d492f7_m5145600_0_A270,o6
+  o19: grating_coupler_array_g_88d492f7_m5145600_0_A270,o7
+  o2: grating_coupler_array_g_88d492f7_5145600_0_A90,o2
+  o20: grating_coupler_array_g_88d492f7_m5145600_0_A270,o8
+  o21: grating_coupler_array_g_88d492f7_m5145600_0_A270,o9
+  o22: grating_coupler_array_g_88d492f7_m5145600_0_A270,o10
+  o23: grating_coupler_array_g_88d492f7_m5145600_0_A270,o11
+  o24: grating_coupler_array_g_88d492f7_m5145600_0_A270,o12
+  o3: grating_coupler_array_g_88d492f7_5145600_0_A90,o3
+  o4: grating_coupler_array_g_88d492f7_5145600_0_A90,o4
+  o5: grating_coupler_array_g_88d492f7_5145600_0_A90,o5
+  o6: grating_coupler_array_g_88d492f7_5145600_0_A90,o6
+  o7: grating_coupler_array_g_88d492f7_5145600_0_A90,o7
+  o8: grating_coupler_array_g_88d492f7_5145600_0_A90,o8
+  o9: grating_coupler_array_g_88d492f7_5145600_0_A90,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test_si500/test_netlists_grating_coupler_array_.yml
+++ b/tests/test_si500/test_netlists_grating_coupler_array_.yml
@@ -1,5 +1,5 @@
 instances:
-  grating_coupler_rectang_2cd63619_190500_0:
+  grating_coupler_rectang_2cd63619_190500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 10
@@ -11,7 +11,7 @@ instances:
       n_periods: 60
       period: 0.57
       wavelength: 1.55
-  grating_coupler_rectang_2cd63619_317500_0:
+  grating_coupler_rectang_2cd63619_317500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 10
@@ -23,7 +23,7 @@ instances:
       n_periods: 60
       period: 0.57
       wavelength: 1.55
-  grating_coupler_rectang_2cd63619_63500_0:
+  grating_coupler_rectang_2cd63619_63500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 10
@@ -35,7 +35,7 @@ instances:
       n_periods: 60
       period: 0.57
       wavelength: 1.55
-  grating_coupler_rectang_2cd63619_m190500_0:
+  grating_coupler_rectang_2cd63619_m190500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 10
@@ -47,7 +47,7 @@ instances:
       n_periods: 60
       period: 0.57
       wavelength: 1.55
-  grating_coupler_rectang_2cd63619_m317500_0:
+  grating_coupler_rectang_2cd63619_m317500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 10
@@ -59,7 +59,7 @@ instances:
       n_periods: 60
       period: 0.57
       wavelength: 1.55
-  grating_coupler_rectang_2cd63619_m63500_0:
+  grating_coupler_rectang_2cd63619_m63500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 10
@@ -74,54 +74,54 @@ instances:
 name: grating_coupler_array_P_03cef4e6
 nets: []
 placements:
-  grating_coupler_rectang_2cd63619_190500_0:
+  grating_coupler_rectang_2cd63619_190500_0_A270:
     mirror: false
     rotation: 270
     x: 190.5
     y: 0
-  grating_coupler_rectang_2cd63619_317500_0:
+  grating_coupler_rectang_2cd63619_317500_0_A270:
     mirror: false
     rotation: 270
     x: 317.5
     y: 0
-  grating_coupler_rectang_2cd63619_63500_0:
+  grating_coupler_rectang_2cd63619_63500_0_A270:
     mirror: false
     rotation: 270
     x: 63.5
     y: 0
-  grating_coupler_rectang_2cd63619_m190500_0:
+  grating_coupler_rectang_2cd63619_m190500_0_A270:
     mirror: false
     rotation: 270
     x: -190.5
     y: 0
-  grating_coupler_rectang_2cd63619_m317500_0:
+  grating_coupler_rectang_2cd63619_m317500_0_A270:
     mirror: false
     rotation: 270
     x: -317.5
     y: 0
-  grating_coupler_rectang_2cd63619_m63500_0:
+  grating_coupler_rectang_2cd63619_m63500_0_A270:
     mirror: false
     rotation: 270
     x: -63.5
     y: 0
 ports:
-  o0: grating_coupler_rectang_2cd63619_m317500_0,o1
-  o1: grating_coupler_rectang_2cd63619_m190500_0,o1
-  o2: grating_coupler_rectang_2cd63619_m63500_0,o1
-  o3: grating_coupler_rectang_2cd63619_63500_0,o1
-  o4: grating_coupler_rectang_2cd63619_190500_0,o1
-  o5: grating_coupler_rectang_2cd63619_317500_0,o1
+  o0: grating_coupler_rectang_2cd63619_m317500_0_A270,o1
+  o1: grating_coupler_rectang_2cd63619_m190500_0_A270,o1
+  o2: grating_coupler_rectang_2cd63619_m63500_0_A270,o1
+  o3: grating_coupler_rectang_2cd63619_63500_0_A270,o1
+  o4: grating_coupler_rectang_2cd63619_190500_0_A270,o1
+  o5: grating_coupler_rectang_2cd63619_317500_0_A270,o1
 warnings:
   vertical_te:
     unconnected_ports:
     - message: 6 unconnected vertical_te ports!
       ports:
-      - grating_coupler_rectang_2cd63619_m317500_0,o2
-      - grating_coupler_rectang_2cd63619_m190500_0,o2
-      - grating_coupler_rectang_2cd63619_m63500_0,o2
-      - grating_coupler_rectang_2cd63619_63500_0,o2
-      - grating_coupler_rectang_2cd63619_190500_0,o2
-      - grating_coupler_rectang_2cd63619_317500_0,o2
+      - grating_coupler_rectang_2cd63619_m317500_0_A270,o2
+      - grating_coupler_rectang_2cd63619_m190500_0_A270,o2
+      - grating_coupler_rectang_2cd63619_m63500_0_A270,o2
+      - grating_coupler_rectang_2cd63619_63500_0_A270,o2
+      - grating_coupler_rectang_2cd63619_190500_0_A270,o2
+      - grating_coupler_rectang_2cd63619_317500_0_A270,o2
       values:
       - - -317.5
         - -366.886

--- a/tests/test_si500/test_settings_coupler_.yml
+++ b/tests/test_si500/test_settings_coupler_.yml
@@ -1,6 +1,6 @@
 info:
-  length: 15.129
   min_bend_radius: 25.392
+  path_length: 50.258
 name: coupler_G0p236_L20_D4_D_681368b1
 settings:
   cross_section: xs_rc

--- a/tests/test_si500/test_settings_coupler_rc_.yml
+++ b/tests/test_si500/test_settings_coupler_rc_.yml
@@ -1,6 +1,6 @@
 info:
-  length: 15.129
   min_bend_radius: 25.392
+  path_length: 50.258
 name: coupler_G0p236_L20_D4_D_681368b1
 settings:
   cross_section: xs_rc

--- a/tests/test_si500/test_settings_coupler_ro_.yml
+++ b/tests/test_si500/test_settings_coupler_ro_.yml
@@ -1,6 +1,6 @@
 info:
-  length: 15.133
   min_bend_radius: 25.036
+  path_length: 50.266
 name: coupler_G0p236_L20_D4_D_4da8fff6
 settings:
   cross_section: xs_ro

--- a/tests/test_sin300.py
+++ b/tests/test_sin300.py
@@ -20,7 +20,7 @@ def activate_pdk() -> None:
 
 
 cells = PDK.cells
-skip_test = {"coupler_symmetric"}
+skip_test = {"coupler_symmetric", "die", "die_nc", "die_no"}
 cell_names = cells.keys() - skip_test
 cell_names = [name for name in cell_names if not name.startswith("_")]
 dirpath = (

--- a/tests/test_sin300/test_netlists_die_.yml
+++ b/tests/test_sin300/test_netlists_die_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_b77eac64_5329600_0:
+  grating_coupler_array_g_dac4c101_5329600_0_A90:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_nc
       grating_coupler: grating_coupler_rectangular_nc
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_b77eac64_m5329600_0:
+  grating_coupler_array_g_dac4c101_m5329600_0_A270:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_nc
       grating_coupler: grating_coupler_rectangular_nc
@@ -603,12 +605,12 @@ instances:
 name: die_CSxs_nc
 nets: []
 placements:
-  grating_coupler_array_g_b77eac64_5329600_0:
+  grating_coupler_array_g_dac4c101_5329600_0_A90:
     mirror: false
     rotation: 90
     x: 5329.6
     y: 0
-  grating_coupler_array_g_b77eac64_m5329600_0:
+  grating_coupler_array_g_dac4c101_m5329600_0_A270:
     mirror: false
     rotation: 270
     x: -5329.6
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_b77eac64_5329600_0,o1
-  o10: grating_coupler_array_g_b77eac64_5329600_0,o10
-  o11: grating_coupler_array_g_b77eac64_5329600_0,o11
-  o12: grating_coupler_array_g_b77eac64_5329600_0,o12
-  o13: grating_coupler_array_g_b77eac64_m5329600_0,o1
-  o14: grating_coupler_array_g_b77eac64_m5329600_0,o2
-  o15: grating_coupler_array_g_b77eac64_m5329600_0,o3
-  o16: grating_coupler_array_g_b77eac64_m5329600_0,o4
-  o17: grating_coupler_array_g_b77eac64_m5329600_0,o5
-  o18: grating_coupler_array_g_b77eac64_m5329600_0,o6
-  o19: grating_coupler_array_g_b77eac64_m5329600_0,o7
-  o2: grating_coupler_array_g_b77eac64_5329600_0,o2
-  o20: grating_coupler_array_g_b77eac64_m5329600_0,o8
-  o21: grating_coupler_array_g_b77eac64_m5329600_0,o9
-  o22: grating_coupler_array_g_b77eac64_m5329600_0,o10
-  o23: grating_coupler_array_g_b77eac64_m5329600_0,o11
-  o24: grating_coupler_array_g_b77eac64_m5329600_0,o12
-  o3: grating_coupler_array_g_b77eac64_5329600_0,o3
-  o4: grating_coupler_array_g_b77eac64_5329600_0,o4
-  o5: grating_coupler_array_g_b77eac64_5329600_0,o5
-  o6: grating_coupler_array_g_b77eac64_5329600_0,o6
-  o7: grating_coupler_array_g_b77eac64_5329600_0,o7
-  o8: grating_coupler_array_g_b77eac64_5329600_0,o8
-  o9: grating_coupler_array_g_b77eac64_5329600_0,o9
+  o1: grating_coupler_array_g_dac4c101_5329600_0_A90,o1
+  o10: grating_coupler_array_g_dac4c101_5329600_0_A90,o10
+  o11: grating_coupler_array_g_dac4c101_5329600_0_A90,o11
+  o12: grating_coupler_array_g_dac4c101_5329600_0_A90,o12
+  o13: grating_coupler_array_g_dac4c101_m5329600_0_A270,o1
+  o14: grating_coupler_array_g_dac4c101_m5329600_0_A270,o2
+  o15: grating_coupler_array_g_dac4c101_m5329600_0_A270,o3
+  o16: grating_coupler_array_g_dac4c101_m5329600_0_A270,o4
+  o17: grating_coupler_array_g_dac4c101_m5329600_0_A270,o5
+  o18: grating_coupler_array_g_dac4c101_m5329600_0_A270,o6
+  o19: grating_coupler_array_g_dac4c101_m5329600_0_A270,o7
+  o2: grating_coupler_array_g_dac4c101_5329600_0_A90,o2
+  o20: grating_coupler_array_g_dac4c101_m5329600_0_A270,o8
+  o21: grating_coupler_array_g_dac4c101_m5329600_0_A270,o9
+  o22: grating_coupler_array_g_dac4c101_m5329600_0_A270,o10
+  o23: grating_coupler_array_g_dac4c101_m5329600_0_A270,o11
+  o24: grating_coupler_array_g_dac4c101_m5329600_0_A270,o12
+  o3: grating_coupler_array_g_dac4c101_5329600_0_A90,o3
+  o4: grating_coupler_array_g_dac4c101_5329600_0_A90,o4
+  o5: grating_coupler_array_g_dac4c101_5329600_0_A90,o5
+  o6: grating_coupler_array_g_dac4c101_5329600_0_A90,o6
+  o7: grating_coupler_array_g_dac4c101_5329600_0_A90,o7
+  o8: grating_coupler_array_g_dac4c101_5329600_0_A90,o8
+  o9: grating_coupler_array_g_dac4c101_5329600_0_A90,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test_sin300/test_netlists_die_nc_.yml
+++ b/tests/test_sin300/test_netlists_die_nc_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_b77eac64_5329600_0:
+  grating_coupler_array_g_dac4c101_5329600_0_A90:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_nc
       grating_coupler: grating_coupler_rectangular_nc
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_b77eac64_m5329600_0:
+  grating_coupler_array_g_dac4c101_m5329600_0_A270:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_nc
       grating_coupler: grating_coupler_rectangular_nc
@@ -603,12 +605,12 @@ instances:
 name: die_CSxs_nc
 nets: []
 placements:
-  grating_coupler_array_g_b77eac64_5329600_0:
+  grating_coupler_array_g_dac4c101_5329600_0_A90:
     mirror: false
     rotation: 90
     x: 5329.6
     y: 0
-  grating_coupler_array_g_b77eac64_m5329600_0:
+  grating_coupler_array_g_dac4c101_m5329600_0_A270:
     mirror: false
     rotation: 270
     x: -5329.6
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_b77eac64_5329600_0,o1
-  o10: grating_coupler_array_g_b77eac64_5329600_0,o10
-  o11: grating_coupler_array_g_b77eac64_5329600_0,o11
-  o12: grating_coupler_array_g_b77eac64_5329600_0,o12
-  o13: grating_coupler_array_g_b77eac64_m5329600_0,o1
-  o14: grating_coupler_array_g_b77eac64_m5329600_0,o2
-  o15: grating_coupler_array_g_b77eac64_m5329600_0,o3
-  o16: grating_coupler_array_g_b77eac64_m5329600_0,o4
-  o17: grating_coupler_array_g_b77eac64_m5329600_0,o5
-  o18: grating_coupler_array_g_b77eac64_m5329600_0,o6
-  o19: grating_coupler_array_g_b77eac64_m5329600_0,o7
-  o2: grating_coupler_array_g_b77eac64_5329600_0,o2
-  o20: grating_coupler_array_g_b77eac64_m5329600_0,o8
-  o21: grating_coupler_array_g_b77eac64_m5329600_0,o9
-  o22: grating_coupler_array_g_b77eac64_m5329600_0,o10
-  o23: grating_coupler_array_g_b77eac64_m5329600_0,o11
-  o24: grating_coupler_array_g_b77eac64_m5329600_0,o12
-  o3: grating_coupler_array_g_b77eac64_5329600_0,o3
-  o4: grating_coupler_array_g_b77eac64_5329600_0,o4
-  o5: grating_coupler_array_g_b77eac64_5329600_0,o5
-  o6: grating_coupler_array_g_b77eac64_5329600_0,o6
-  o7: grating_coupler_array_g_b77eac64_5329600_0,o7
-  o8: grating_coupler_array_g_b77eac64_5329600_0,o8
-  o9: grating_coupler_array_g_b77eac64_5329600_0,o9
+  o1: grating_coupler_array_g_dac4c101_5329600_0_A90,o1
+  o10: grating_coupler_array_g_dac4c101_5329600_0_A90,o10
+  o11: grating_coupler_array_g_dac4c101_5329600_0_A90,o11
+  o12: grating_coupler_array_g_dac4c101_5329600_0_A90,o12
+  o13: grating_coupler_array_g_dac4c101_m5329600_0_A270,o1
+  o14: grating_coupler_array_g_dac4c101_m5329600_0_A270,o2
+  o15: grating_coupler_array_g_dac4c101_m5329600_0_A270,o3
+  o16: grating_coupler_array_g_dac4c101_m5329600_0_A270,o4
+  o17: grating_coupler_array_g_dac4c101_m5329600_0_A270,o5
+  o18: grating_coupler_array_g_dac4c101_m5329600_0_A270,o6
+  o19: grating_coupler_array_g_dac4c101_m5329600_0_A270,o7
+  o2: grating_coupler_array_g_dac4c101_5329600_0_A90,o2
+  o20: grating_coupler_array_g_dac4c101_m5329600_0_A270,o8
+  o21: grating_coupler_array_g_dac4c101_m5329600_0_A270,o9
+  o22: grating_coupler_array_g_dac4c101_m5329600_0_A270,o10
+  o23: grating_coupler_array_g_dac4c101_m5329600_0_A270,o11
+  o24: grating_coupler_array_g_dac4c101_m5329600_0_A270,o12
+  o3: grating_coupler_array_g_dac4c101_5329600_0_A90,o3
+  o4: grating_coupler_array_g_dac4c101_5329600_0_A90,o4
+  o5: grating_coupler_array_g_dac4c101_5329600_0_A90,o5
+  o6: grating_coupler_array_g_dac4c101_5329600_0_A90,o6
+  o7: grating_coupler_array_g_dac4c101_5329600_0_A90,o7
+  o8: grating_coupler_array_g_dac4c101_5329600_0_A90,o8
+  o9: grating_coupler_array_g_dac4c101_5329600_0_A90,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test_sin300/test_netlists_die_no_.yml
+++ b/tests/test_sin300/test_netlists_die_no_.yml
@@ -1,8 +1,9 @@
 instances:
-  grating_coupler_array_g_737a5d1b_5320605_0:
+  grating_coupler_array_g_37373fb7_5320605_0_A90:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_no
       grating_coupler: grating_coupler_rectangular_no
@@ -13,10 +14,11 @@ instances:
       rotation: -90
       straight_to_grating_spacing: 10
       with_loopback: true
-  grating_coupler_array_g_737a5d1b_m5320605_0:
+  grating_coupler_array_g_37373fb7_m5320605_0_A270:
     component: grating_coupler_array
     info: {}
     settings:
+      bend: bend_euler
       centered: true
       cross_section: xs_no
       grating_coupler: grating_coupler_rectangular_no
@@ -603,12 +605,12 @@ instances:
 name: die_CSxs_no
 nets: []
 placements:
-  grating_coupler_array_g_737a5d1b_5320605_0:
+  grating_coupler_array_g_37373fb7_5320605_0_A90:
     mirror: false
     rotation: 90
     x: 5320.605
     y: 0
-  grating_coupler_array_g_737a5d1b_m5320605_0:
+  grating_coupler_array_g_37373fb7_m5320605_0_A270:
     mirror: false
     rotation: 270
     x: -5320.605
@@ -991,30 +993,30 @@ ports:
   e7: pad_m2650000_m2250000,e2
   e8: pad_m2350000_m2250000,e2
   e9: pad_m2050000_m2250000,e2
-  o1: grating_coupler_array_g_737a5d1b_5320605_0,o1
-  o10: grating_coupler_array_g_737a5d1b_5320605_0,o10
-  o11: grating_coupler_array_g_737a5d1b_5320605_0,o11
-  o12: grating_coupler_array_g_737a5d1b_5320605_0,o12
-  o13: grating_coupler_array_g_737a5d1b_m5320605_0,o1
-  o14: grating_coupler_array_g_737a5d1b_m5320605_0,o2
-  o15: grating_coupler_array_g_737a5d1b_m5320605_0,o3
-  o16: grating_coupler_array_g_737a5d1b_m5320605_0,o4
-  o17: grating_coupler_array_g_737a5d1b_m5320605_0,o5
-  o18: grating_coupler_array_g_737a5d1b_m5320605_0,o6
-  o19: grating_coupler_array_g_737a5d1b_m5320605_0,o7
-  o2: grating_coupler_array_g_737a5d1b_5320605_0,o2
-  o20: grating_coupler_array_g_737a5d1b_m5320605_0,o8
-  o21: grating_coupler_array_g_737a5d1b_m5320605_0,o9
-  o22: grating_coupler_array_g_737a5d1b_m5320605_0,o10
-  o23: grating_coupler_array_g_737a5d1b_m5320605_0,o11
-  o24: grating_coupler_array_g_737a5d1b_m5320605_0,o12
-  o3: grating_coupler_array_g_737a5d1b_5320605_0,o3
-  o4: grating_coupler_array_g_737a5d1b_5320605_0,o4
-  o5: grating_coupler_array_g_737a5d1b_5320605_0,o5
-  o6: grating_coupler_array_g_737a5d1b_5320605_0,o6
-  o7: grating_coupler_array_g_737a5d1b_5320605_0,o7
-  o8: grating_coupler_array_g_737a5d1b_5320605_0,o8
-  o9: grating_coupler_array_g_737a5d1b_5320605_0,o9
+  o1: grating_coupler_array_g_37373fb7_5320605_0_A90,o1
+  o10: grating_coupler_array_g_37373fb7_5320605_0_A90,o10
+  o11: grating_coupler_array_g_37373fb7_5320605_0_A90,o11
+  o12: grating_coupler_array_g_37373fb7_5320605_0_A90,o12
+  o13: grating_coupler_array_g_37373fb7_m5320605_0_A270,o1
+  o14: grating_coupler_array_g_37373fb7_m5320605_0_A270,o2
+  o15: grating_coupler_array_g_37373fb7_m5320605_0_A270,o3
+  o16: grating_coupler_array_g_37373fb7_m5320605_0_A270,o4
+  o17: grating_coupler_array_g_37373fb7_m5320605_0_A270,o5
+  o18: grating_coupler_array_g_37373fb7_m5320605_0_A270,o6
+  o19: grating_coupler_array_g_37373fb7_m5320605_0_A270,o7
+  o2: grating_coupler_array_g_37373fb7_5320605_0_A90,o2
+  o20: grating_coupler_array_g_37373fb7_m5320605_0_A270,o8
+  o21: grating_coupler_array_g_37373fb7_m5320605_0_A270,o9
+  o22: grating_coupler_array_g_37373fb7_m5320605_0_A270,o10
+  o23: grating_coupler_array_g_37373fb7_m5320605_0_A270,o11
+  o24: grating_coupler_array_g_37373fb7_m5320605_0_A270,o12
+  o3: grating_coupler_array_g_37373fb7_5320605_0_A90,o3
+  o4: grating_coupler_array_g_37373fb7_5320605_0_A90,o4
+  o5: grating_coupler_array_g_37373fb7_5320605_0_A90,o5
+  o6: grating_coupler_array_g_37373fb7_5320605_0_A90,o6
+  o7: grating_coupler_array_g_37373fb7_5320605_0_A90,o7
+  o8: grating_coupler_array_g_37373fb7_5320605_0_A90,o8
+  o9: grating_coupler_array_g_37373fb7_5320605_0_A90,o9
 warnings:
   electrical:
     unconnected_ports:

--- a/tests/test_sin300/test_netlists_grating_coupler_array_.yml
+++ b/tests/test_sin300/test_netlists_grating_coupler_array_.yml
@@ -1,5 +1,5 @@
 instances:
-  grating_coupler_rectang_27811604_190500_0:
+  grating_coupler_rectang_27811604_190500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 20
@@ -11,7 +11,7 @@ instances:
       n_periods: 30
       period: 0.66
       wavelength: 1.55
-  grating_coupler_rectang_27811604_317500_0:
+  grating_coupler_rectang_27811604_317500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 20
@@ -23,7 +23,7 @@ instances:
       n_periods: 30
       period: 0.66
       wavelength: 1.55
-  grating_coupler_rectang_27811604_63500_0:
+  grating_coupler_rectang_27811604_63500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 20
@@ -35,7 +35,7 @@ instances:
       n_periods: 30
       period: 0.66
       wavelength: 1.55
-  grating_coupler_rectang_27811604_m190500_0:
+  grating_coupler_rectang_27811604_m190500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 20
@@ -47,7 +47,7 @@ instances:
       n_periods: 30
       period: 0.66
       wavelength: 1.55
-  grating_coupler_rectang_27811604_m317500_0:
+  grating_coupler_rectang_27811604_m317500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 20
@@ -59,7 +59,7 @@ instances:
       n_periods: 30
       period: 0.66
       wavelength: 1.55
-  grating_coupler_rectang_27811604_m63500_0:
+  grating_coupler_rectang_27811604_m63500_0_A270:
     component: grating_coupler_rectangular
     info:
       fiber_angle: 20
@@ -74,54 +74,54 @@ instances:
 name: grating_coupler_array_P_7b5bab83
 nets: []
 placements:
-  grating_coupler_rectang_27811604_190500_0:
+  grating_coupler_rectang_27811604_190500_0_A270:
     mirror: false
     rotation: 270
     x: 190.5
     y: 0
-  grating_coupler_rectang_27811604_317500_0:
+  grating_coupler_rectang_27811604_317500_0_A270:
     mirror: false
     rotation: 270
     x: 317.5
     y: 0
-  grating_coupler_rectang_27811604_63500_0:
+  grating_coupler_rectang_27811604_63500_0_A270:
     mirror: false
     rotation: 270
     x: 63.5
     y: 0
-  grating_coupler_rectang_27811604_m190500_0:
+  grating_coupler_rectang_27811604_m190500_0_A270:
     mirror: false
     rotation: 270
     x: -190.5
     y: 0
-  grating_coupler_rectang_27811604_m317500_0:
+  grating_coupler_rectang_27811604_m317500_0_A270:
     mirror: false
     rotation: 270
     x: -317.5
     y: 0
-  grating_coupler_rectang_27811604_m63500_0:
+  grating_coupler_rectang_27811604_m63500_0_A270:
     mirror: false
     rotation: 270
     x: -63.5
     y: 0
 ports:
-  o0: grating_coupler_rectang_27811604_m317500_0,o1
-  o1: grating_coupler_rectang_27811604_m190500_0,o1
-  o2: grating_coupler_rectang_27811604_m63500_0,o1
-  o3: grating_coupler_rectang_27811604_63500_0,o1
-  o4: grating_coupler_rectang_27811604_190500_0,o1
-  o5: grating_coupler_rectang_27811604_317500_0,o1
+  o0: grating_coupler_rectang_27811604_m317500_0_A270,o1
+  o1: grating_coupler_rectang_27811604_m190500_0_A270,o1
+  o2: grating_coupler_rectang_27811604_m63500_0_A270,o1
+  o3: grating_coupler_rectang_27811604_63500_0_A270,o1
+  o4: grating_coupler_rectang_27811604_190500_0_A270,o1
+  o5: grating_coupler_rectang_27811604_317500_0_A270,o1
 warnings:
   vertical_te:
     unconnected_ports:
     - message: 6 unconnected vertical_te ports!
       ports:
-      - grating_coupler_rectang_27811604_m317500_0,o2
-      - grating_coupler_rectang_27811604_m190500_0,o2
-      - grating_coupler_rectang_27811604_m63500_0,o2
-      - grating_coupler_rectang_27811604_63500_0,o2
-      - grating_coupler_rectang_27811604_190500_0,o2
-      - grating_coupler_rectang_27811604_317500_0,o2
+      - grating_coupler_rectang_27811604_m317500_0_A270,o2
+      - grating_coupler_rectang_27811604_m190500_0_A270,o2
+      - grating_coupler_rectang_27811604_m63500_0_A270,o2
+      - grating_coupler_rectang_27811604_63500_0_A270,o2
+      - grating_coupler_rectang_27811604_190500_0_A270,o2
+      - grating_coupler_rectang_27811604_317500_0_A270,o2
       values:
       - - -317.5
         - -209.652

--- a/tests/test_sin300/test_settings_coupler_.yml
+++ b/tests/test_sin300/test_settings_coupler_.yml
@@ -1,6 +1,6 @@
 info:
-  length: 20.058
   min_bend_radius: 57.149
+  path_length: 60.116
 name: coupler_G0p236_L20_D4_D_a568a907
 settings:
   cross_section: xs_nc

--- a/tests/test_sin300/test_settings_coupler_nc_.yml
+++ b/tests/test_sin300/test_settings_coupler_nc_.yml
@@ -1,6 +1,6 @@
 info:
-  length: 20.058
   min_bend_radius: 57.149
+  path_length: 60.116
 name: coupler_G0p236_L20_D4_D_a568a907
 settings:
   cross_section: xs_nc

--- a/tests/test_sin300/test_settings_coupler_no_.yml
+++ b/tests/test_sin300/test_settings_coupler_no_.yml
@@ -1,6 +1,6 @@
 info:
-  length: 20.07
   min_bend_radius: 52.186
+  path_length: 60.14
 name: coupler_G0p236_L20_D4_D_3f0984fa
 settings:
   cross_section: xs_no


### PR DESCRIPTION
## Summary by Sourcery

Update netlist test fixtures to include explicit orientation/mirror suffixes, adjust coupler settings and path_length info, and bump project dependencies and test configurations.

Enhancements:
- Embed rotation and mirror suffixes in component instance names and references across all YAML netlist tests
- Switch coupler definitions from `length` to `path_length` and add missing `bend` setting for grating coupler arrays
- Update Makefile to invoke `test_si220_cband.py` and adjust pytest skip lists for new cells
- Modify main invocation in `cspdk/si500/cells.py` to display `die_rc()` by default

Build:
- Bump gdsfactory to 9.7.0, update gplugins[sax] constraint, and broaden package-data globs in pyproject.toml