### PR TITLE
Fix models for Oband

### DIFF
--- a/cspdk/si220/oband/models.py
+++ b/cspdk/si220/oband/models.py
@@ -23,7 +23,7 @@ Float = float | FloatArray
 straight_strip = partial(
     sm.straight,
     length=10.0,
-    loss=0.0,
+    loss_dB_cm=0.0,
     wl0=1.31,
     neff=2.52,
     ng=4.33,
@@ -32,7 +32,7 @@ straight_strip = partial(
 straight_rib = partial(
     sm.straight,
     length=10.0,
-    loss=0.0,
+    loss_dB_cm=0.0,
     wl0=1.31,
     neff=2.72,
     ng=3.98,
@@ -43,7 +43,7 @@ def straight(
     *,
     wl: Float = 1.31,
     length: float = 10.0,
-    loss: float = 0.0,
+    loss_dB_cm: float = 0.0,
     cross_section: str = "strip",
 ) -> sax.SDict:
     """Straight waveguide model."""
@@ -56,7 +56,7 @@ def straight(
     return f(
         wl=wl,  # type: ignore
         length=length,
-        loss=loss,
+        loss_dB_cm=loss_dB_cm,
     )
 
 
@@ -76,7 +76,7 @@ def bend_s(
     *,
     wl: Float = 1.31,
     length: float = 10.0,
-    loss: float = 0.03,
+    loss_dB_cm: float = 3.0,
     cross_section="strip",
 ) -> sax.SDict:
     """Bend S model."""
@@ -84,7 +84,7 @@ def bend_s(
     return straight(
         wl=wl,
         length=length,
-        loss=loss,
+        loss_dB_cm=loss_dB_cm,
         cross_section=cross_section,
     )
 
@@ -93,7 +93,7 @@ def bend_euler(
     *,
     wl: Float = 1.31,
     length: float = 10.0,
-    loss: float = 0.03,
+    loss_dB_cm: float = 3.0,
     cross_section="strip",
 ) -> sax.SDict:
     """Euler bend model."""
@@ -101,7 +101,7 @@ def bend_euler(
     return straight(
         wl=wl,
         length=length,
-        loss=loss,
+        loss_dB_cm=loss_dB_cm,
         cross_section=cross_section,
     )
 
@@ -141,7 +141,7 @@ def taper_strip_to_ridge(
     *,
     wl: Float = 1.31,
     length: float = 10.0,
-    loss: float = 0.0,
+    loss_dB_cm: float = 0.0,
     cross_section="strip",
 ) -> sax.SDict:
     """Taper strip to ridge model."""
@@ -150,7 +150,7 @@ def taper_strip_to_ridge(
     return straight(
         wl=wl,
         length=length,
-        loss=loss,
+        loss_dB_cm=loss_dB_cm,
         cross_section=cross_section,
     )
 

--- a/cspdk/si220/oband/models.py
+++ b/cspdk/si220/oband/models.py
@@ -106,7 +106,7 @@ def bend_euler(
     )
 
 
-bend_euler = partial(bend_euler, cross_section="strip")
+bend_euler_strip = partial(bend_euler, cross_section="strip")
 bend_euler_rib = partial(bend_euler, cross_section="rib")
 
 
@@ -134,7 +134,6 @@ def taper(
 
 
 taper_rib = partial(taper, cross_section="rib", length=10.0)
-taper_ro = partial(taper, cross_section="xs_ro", length=10.0)
 
 
 def taper_strip_to_ridge(
@@ -239,10 +238,10 @@ def coupler(
 # grating couplers Rectangular
 ##############################
 
-grating_coupler_rectangular = partial(
+grating_coupler_rectangular_strip = partial(
     sm.grating_coupler, loss=6, bandwidth=35 * nm, wl=1.31
 )
-grating_coupler_rectangular_rib = grating_coupler_rectangular
+grating_coupler_rectangular_rib = grating_coupler_rectangular_strip
 
 
 def grating_coupler_rectangular(
@@ -253,7 +252,7 @@ def grating_coupler_rectangular(
     # TODO: take more grating_coupler_rectangular arguments into account
     wl = jnp.asarray(wl)  # type: ignore
     fs = {
-        "strip": grating_coupler_rectangular,
+        "strip": grating_coupler_rectangular_strip,
         "rib": grating_coupler_rectangular_rib,
     }
     f = fs[cross_section]
@@ -264,7 +263,7 @@ def grating_coupler_rectangular(
 # grating couplers Elliptical
 ##############################
 
-grating_coupler_elliptical = partial(
+grating_coupler_elliptical_strip = partial(
     sm.grating_coupler, loss=6, bandwidth=35 * nm, wl=1.31
 )
 

--- a/cspdk/si220/oband/models.py
+++ b/cspdk/si220/oband/models.py
@@ -119,7 +119,7 @@ def taper(
     *,
     wl: Float = 1.31,
     length: float = 10.0,
-    loss: float = 0.0,
+    loss_dB_cm: float = 0.0,
     cross_section="strip",
 ) -> sax.SDict:
     """Taper model."""
@@ -128,7 +128,7 @@ def taper(
     return straight(
         wl=wl,
         length=length,
-        loss=loss,
+        loss_dB_cm=loss_dB_cm,
         cross_section=cross_section,
     )
 

--- a/cspdk/si220/oband/models.py
+++ b/cspdk/si220/oband/models.py
@@ -263,7 +263,7 @@ def grating_coupler_rectangular(
 # grating couplers Elliptical
 ##############################
 
-grating_coupler_elliptical_strip = partial(
+grating_coupler_elliptical = partial(
     sm.grating_coupler, loss=6, bandwidth=35 * nm, wl=1.31
 )
 


### PR DESCRIPTION
This PR makes analogous changes to those of #138 but for o-band in order to fix the models.

## Summary by Sourcery

Fix and standardize loss parameter naming and defaults in o-band photonic component models

Enhancements:
- Change 'loss' parameter to 'loss_dB_cm' across all oband model functions
- Adjust default loss values for bends to 3.0 dB/cm
- Rename bend_euler partial to bend_euler_strip for consistency
- Rename rectangular and elliptical grating coupler partials to include '_strip' suffix and update dispatch mapping