### PR TITLE
add route samples

### DIFF
--- a/cspdk/si220/cband/samples/sample_routing_from_yaml.py
+++ b/cspdk/si220/cband/samples/sample_routing_from_yaml.py
@@ -1,0 +1,68 @@
+"""Circuit simulation with routes."""
+
+if __name__ == "__main__":
+    import gdsfactory as gf
+
+    yaml = """
+
+# yaml-language-server: $schema=../build/schemas/top.json
+instances:
+  instance4:
+    component: pad
+    settings: {}
+  instance1:
+    component: pad
+    settings: {}
+  instance3:
+    component: pad
+    settings: {}
+  instance2:
+    component: pad
+    settings: {}
+connections: {}
+routes:
+  bundle:
+    links:
+      instance1-3,e3: instance2-4,e1
+    routing_strategy: route_bundle_metal
+    settings:
+      end_straight_length: 3
+      min_straight_taper: 3
+      separation: 3
+      sort_ports: true
+      start_straight_length: 3
+nets: []
+ports: {}
+placements:
+  instance4:
+    x: 0.0
+    y: 0.0
+    dx: 931.0809936523438
+    dy: 376.8970031738281
+    rotation: 0.0
+    mirror: false
+  instance1:
+    x: 0.0
+    y: 0.0
+    dx: -120.66300201416016
+    dy: 216.0260009765625
+    rotation: 0.0
+    mirror: false
+  instance3:
+    x: -97.469
+    y: -22.356
+    dx: -14.163
+    dy: -98.992
+  instance2:
+    x: 0.0
+    y: 0.0
+    dx: 884.3419799804688
+    dy: 804.1840209960938
+    rotation: 0.0
+    mirror: false
+
+"""
+
+    c = gf.read.from_yaml(yaml)
+
+    c.show()

--- a/cspdk/si220/cband/samples/sample_routing_from_yaml.py
+++ b/cspdk/si220/cband/samples/sample_routing_from_yaml.py
@@ -1,7 +1,11 @@
-"""Circuit simulation with routes."""
+"""Sample pads with routes."""
 
 if __name__ == "__main__":
     import gdsfactory as gf
+
+    from cspdk.si220.cband import PDK
+
+    PDK.activate()
 
     yaml = """
 

--- a/cspdk/si220/cband/samples/sample_routing_from_yaml_with_steps.py
+++ b/cspdk/si220/cband/samples/sample_routing_from_yaml_with_steps.py
@@ -1,7 +1,11 @@
-"""Circuit simulation with routes."""
+"""Sample pads with routes."""
 
 if __name__ == "__main__":
     import gdsfactory as gf
+
+    from cspdk.si220.cband import PDK
+
+    PDK.activate()
 
     yaml = """
 # yaml-language-server: $schema=../build/schemas/top.json
@@ -25,14 +29,15 @@ connections: {}
 routes:
   bundle:
     links:
-      bl,e3: br,e1
       tl,e3: tr,e1
+      bl,e3: br,e1
     routing_strategy: route_bundle_metal
     settings:
       end_straight_length: 3
       min_straight_taper: 3
       separation: 3
       start_straight_length: 3
+      layer_marker: [1, 0]
       steps:
       - dx: 400.0
       - dy: 500.0

--- a/cspdk/si220/cband/samples/sample_routing_from_yaml_with_steps.py
+++ b/cspdk/si220/cband/samples/sample_routing_from_yaml_with_steps.py
@@ -1,0 +1,81 @@
+"""Circuit simulation with routes."""
+
+if __name__ == "__main__":
+    import gdsfactory as gf
+
+    yaml = """
+# yaml-language-server: $schema=../build/schemas/top.json
+instances:
+  tr:
+    component: pad
+    settings: {}
+  bl:
+    component: pad
+    settings: {}
+  br:
+    component: pad
+    settings: {}
+  obstacle:
+    component: pad
+    settings: {}
+  tl:
+    component: pad
+    settings: {}
+connections: {}
+routes:
+  bundle:
+    links:
+      bl,e3: br,e1
+      tl,e3: tr,e1
+    routing_strategy: route_bundle_metal
+    settings:
+      end_straight_length: 3
+      min_straight_taper: 3
+      separation: 3
+      start_straight_length: 3
+      steps:
+      - dx: 400.0
+      - dy: 500.0
+nets: []
+ports: {}
+placements:
+  tr:
+    x: 0.0
+    y: 0.0
+    dx: 1203.52099609375
+    dy: 808.427001953125
+    rotation: 0.0
+    mirror: false
+  bl:
+    x: -97.469
+    y: -22.356
+    dx: 542.6489868164062
+    dy: 177.4250030517578
+    rotation: 0.0
+    mirror: false
+  br:
+    x: 0.0
+    y: 0.0
+    dx: 1194.5660400390625
+    dy: 597.3690185546875
+    rotation: 0.0
+    mirror: false
+  obstacle:
+    x: 494.896
+    y: 157.058
+    dx: 129.258
+    dy: 288.459
+  tl:
+    x: 0.0
+    y: 0.0
+    dx: 356.6059875488281
+    dy: 313.4670104980469
+    rotation: 0.0
+    mirror: false
+
+
+"""
+
+    c = gf.read.from_yaml(yaml)
+
+    c.show()

--- a/cspdk/si220/cband/samples/sample_routing_from_yaml_with_steps_separation.py
+++ b/cspdk/si220/cband/samples/sample_routing_from_yaml_with_steps_separation.py
@@ -1,0 +1,83 @@
+"""Sample pads with routes."""
+
+if __name__ == "__main__":
+    import gdsfactory as gf
+
+    from cspdk.si220.cband import PDK
+
+    PDK.activate()
+
+    yaml = """
+# yaml-language-server: $schema=../build/schemas/top.json
+instances:
+  tr:
+    component: pad
+    settings: {}
+  bl:
+    component: pad
+    settings: {}
+  br:
+    component: pad
+    settings: {}
+  obstacle:
+    component: pad
+    settings: {}
+  tl:
+    component: pad
+    settings: {}
+connections: {}
+routes:
+  bundle:
+    links:
+      tl,e3: tr,e1
+      bl,e3: br,e1
+    routing_strategy: route_bundle_metal
+    settings:
+      end_straight_length: 3
+      min_straight_taper: 3
+      separation: 3
+      start_straight_length: 3
+      layer_marker: [1, 0]
+nets: []
+ports: {}
+placements:
+  tr:
+    x: 0.0
+    y: 0.0
+    dx: 1203.52099609375
+    dy: 808.427001953125
+    rotation: 0.0
+    mirror: false
+  bl:
+    x: -97.469
+    y: -22.356
+    dx: 542.6489868164062
+    dy: 177.4250030517578
+    rotation: 0.0
+    mirror: false
+  br:
+    x: 0.0
+    y: 0.0
+    dx: 1194.5660400390625
+    dy: 597.3690185546875
+    rotation: 0.0
+    mirror: false
+  obstacle:
+    x: 494.896
+    y: 157.058
+    dx: 129.258
+    dy: 288.459
+  tl:
+    x: 0.0
+    y: 0.0
+    dx: 356.6059875488281
+    dy: 313.4670104980469
+    rotation: 0.0
+    mirror: false
+
+
+"""
+
+    c = gf.read.from_yaml(yaml)
+
+    c.show()

--- a/cspdk/si220/cband/samples/sample_routing_metal.py
+++ b/cspdk/si220/cband/samples/sample_routing_metal.py
@@ -1,0 +1,22 @@
+"""Circuit simulation with routes."""
+
+if __name__ == "__main__":
+    import gdsfactory as gf
+
+    from cspdk.si220.cband import cells, tech
+
+    c = gf.Component()
+    ptl = c << cells.pad()
+    pbl = c << cells.pad()
+    ptr = c << cells.pad()
+    pbr = c << cells.pad()
+
+    dx = 500
+
+    ptr.dmove((dx, 400 + 500))
+    ptl.dmove((0, 400))
+    pbr.move((dx, 200 + 500))
+    route = tech.route_bundle_metal(
+        c, [ptl.ports["e3"], pbl.ports["e3"]], [ptr.ports["e1"], pbr.ports["e1"]]
+    )
+    c.show()


### PR DESCRIPTION
## Summary

Add sample scripts to demonstrate routing functionality for cspdk.si220.cband using both YAML-based configurations and direct API calls

New Features:
- Add sample_routing_from_yaml_with_steps.py to showcase routing from a YAML definition with explicit step parameters
- Add sample_routing_from_yaml.py to demonstrate basic routing from a YAML configuration
- Add sample_routing_metal.py to illustrate programmatic metal bundle routing using the API




<img width="793" height="683" alt="image" src="https://github.com/user-attachments/assets/66afc1c8-84aa-4d36-a992-28a7cea4d766" />
