### PR TITLE
python 313/4 bump

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install dependencies

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent"
 ]
 dependencies = [
@@ -24,7 +25,7 @@ keywords = ["python"]
 license = {file = "LICENSE"}
 name = "cspdk"
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.11,<3.15"
 version = "1.4.2"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary by Sourcery

Expand project and CI configuration to support Python 3.14.

Enhancements:
- Declare Python 3.14 support in project metadata and widen supported Python version range to <3.15.

CI:
- Update GitHub Actions workflows to run tests and docs builds using Python 3.14.