### PR TITLE
Add sheron-lian and thanojo to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @nikosavola
+* @joamatab @ThomasPluck @nikosavola @sheron-lian @thanojo

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ docs/cells_si220_cband.rst
 docs/cells_si220_oband.rst
 
 sim-data-*/
+tests/gds_run/
+
 
 # C extensions
 *.so


### PR DESCRIPTION
## Summary
- Add @sheron-lian and @thanojo as code owners

## Summary by Sourcery

Chores:
- Add new developers as code owners in the CODEOWNERS configuration.