### PR TITLE
Add uv.lock exclude to pretty-format-toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,11 @@ repos:
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
       - id: ruff-format
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.14.0
+    rev: v2.16.0
     hooks:
       - id: pretty-format-toml
         args: [--autofix]
+        exclude: ^uv\.lock$
   - repo: https://github.com/aristanetworks/j2lint.git
     rev: v1.1.0
     hooks:


### PR DESCRIPTION
## Summary
- Bump `language-formatters-pre-commit-hooks` to v2.16.0
- Add `exclude: ^uv\.lock$` to `pretty-format-toml` hook

## Test plan
- [ ] Verify pre-commit hooks still pass

## Summary by Sourcery

Update pre-commit configuration to use a newer version of the TOML formatting hooks and exclude uv.lock from TOML pretty-formatting.

Build:
- Bump language-formatters-pre-commit-hooks to v2.16.0 in the pre-commit configuration.

Chores:
- Exclude uv.lock from the pretty-format-toml pre-commit hook to avoid formatting that lockfile.