### PR TITLE
add DRC workflow

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -1,0 +1,10 @@
+name: DRC Check
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  drc:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/drc.yml@main
+    secrets: inherit

--- a/build_cell.py
+++ b/build_cell.py
@@ -1,0 +1,12 @@
+"""Build a cell and write it to build/gds/<cell_name>.gds."""
+
+import sys
+from pathlib import Path
+
+from gdsfactoryplus.core.pdk import get_pdk, register_cells
+
+cell_name = sys.argv[1]
+Path("build/gds").mkdir(parents=True, exist_ok=True)
+register_cells()
+c = get_pdk().cells[cell_name]()
+c.write_gds(f"build/gds/{cell_name}.gds")


### PR DESCRIPTION
Add DRC check workflow and build_cell.py.

## Summary by Sourcery

Add a script to build and export individual cell GDS files and introduce a GitHub Actions workflow to run DRC checks on pushes to main and on manual dispatch.

Build:
- Add build_cell.py to generate GDS outputs for specified cells into the build/gds directory.

CI:
- Add a reusable GitHub Actions workflow configuration to run DRC checks using the shared pdk-ci-workflow.