### PR TITLE
ci(dependabot): switch to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
+    directory: /
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: "doplaydo/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "uv"
+    cooldown:
+      default-days: 7
     directory: "/"
     schedule:
       interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "doplaydo/*"
 
   - package-ecosystem: github-actions
     cooldown:


### PR DESCRIPTION
Replaces the old pip-based Dependabot config (or adds one) using the centralized template from `doplaydo/pdk-ci-workflow/templates/.github/dependabot.yml`:

- `package-ecosystem: uv` (requires `uv.lock`)
- 7-day cooldown on github-actions updates
- Ignores `doplaydo/*` action updates (managed centrally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure Dependabot to manage uv-based dependencies and GitHub Actions updates using the centralized template settings.

CI:
- Add Dependabot configuration for uv package ecosystem with monthly updates.
- Configure Dependabot to update GitHub Actions monthly with a 7-day cooldown and to ignore doplaydo/* actions.