### PR TITLE
bump gdsfactory to ~=9.40.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["flit_core >=3.2,<4"]
 
 [project]
 authors = [
-  {name = "gdsfactory", email = "contact@gdsfactory.com"}
+  {name = "gdsfactory~=9.40.2", email = "contact@gdsfactory.com"}
 ]
 classifiers = [
   "Programming Language :: Python :: 3.11",
@@ -15,7 +15,7 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 dependencies = [
-  "gdsfactory~=9.40.0",
+  "gdsfactory~=9.40.2",
   "gplugins[sax,femwell,tidy3d]~=2.0.1",
   "doroutes~=0.5.0"
 ]
@@ -35,7 +35,7 @@ dev = [
   "pytest-cov",
   "pytest_regressions",
   "pytest-github-actions-annotate-failures",
-  "gdsfactoryplus",
+  "gdsfactory~=9.40.2",
   "towncrier"
 ]
 docs = ["jupytext", "matplotlib", "jupyter-book>=0.15.1,<1.1", "gsim; python_version>='3.12'"]
@@ -146,7 +146,7 @@ regex = '''
 directory = ".changelog.d"
 filename = "CHANGELOG.md"
 issue_format = "[#{issue}](https://github.com/gdsfactory/cspdk/issues/{issue})"
-package = "gdsfactory"
+package = "gdsfactory~=9.40.2"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".changelog.d/changelog_template.jinja"
 title_format = "## [{version}](https://github.com/gdsfactory/cspdk/releases/tag/v{version}) - {project_date}"


### PR DESCRIPTION
## Summary

- Bump gdsfactory from `gdsfactory~=9.40.0` to `~=9.40.2`
- Fixes [gdsfactory/gdsfactory#4485](https://github.com/gdsfactory/gdsfactory/issues/4485): `Pdk.__init__` in 9.40.0 didn't copy `__pydantic_extra__` slot, causing `copy.copy(pdk)` to raise `AttributeError`
- This crashed GF+ server on startup (`get_base_pdk` calls `copy(pdk)`)
- 9.40.1 has the fix, 9.40.2 adds regression test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)