### PR TITLE
Sync .github templates with upstream pdk-ci-workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,12 +1,11 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-change-template: '- $TITLE [#$NUMBER](https://github.com/gdsfactory/cspdk/pull/$NUMBER)'
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&'
 template: |
   # What's Changed
 
   $CHANGES
-
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 categories:
   - title: 'Breaking'
     label: 'breaking'
@@ -22,10 +21,10 @@ categories:
       - 'github_actions'
   - title: 'Documentation'
     label: 'documentation'
-  - title: 'Other changes'
   - title: 'Dependency Updates'
     label: 'dependencies'
     collapse-after: 5
+
 version-resolver:
   major:
     labels:
@@ -45,8 +44,10 @@ version-resolver:
       - 'dependencies'
       - 'security'
   default: patch
+
 exclude-labels:
   - 'skip-changelog'
+
 autolabeler:
   - label: 'documentation'
     files:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -4,14 +4,8 @@ on:
     types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
 
 jobs:
   review:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    secrets: inherit

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -17,6 +17,7 @@ on:
       - transferred
       - milestoned
       - demilestoned
+
 jobs:
   label:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/issue.yml@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,13 +4,8 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
-    secrets:
-      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+    secrets: inherit

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,6 +2,9 @@ name: Release Drafter
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+
 jobs:
   draft:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main
+    secrets: inherit

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -3,8 +3,8 @@ on:
   pull_request:
   push:
     branches: [main]
+
 jobs:
   test:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
-    secrets:
-      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+    secrets: inherit


### PR DESCRIPTION
Syncs workflow templates and config files with the canonical versions from doplaydo/pdk-ci-workflow.

Also fixes CODEOWNERS trailing newline for pre-commit compliance.

## Summary by Sourcery

Align GitHub workflows and release-drafter configuration with the canonical pdk-ci-workflow templates and simplify secret/permission handling.

Build:
- Update Release Drafter configuration to match upstream defaults, including a simplified change template and adjusted categories.
- Switch reusable GitHub Actions workflows to inherit secrets and permissions from the caller instead of declaring explicit secrets.
- Enable manual dispatch for the Release Drafter workflow and tidy workflow YAML formatting.