### PR TITLE
add layer_transitions to PDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ rm-samples:
 test:
 	uv run pytest -s tests/test_si220_cband.py
 	uv run pytest -s tests/test_si220_oband.py
+	uv run pytest -s tests/test_routing.py
 	# uv run pytest -s tests/test_si500.py
 	# uv run pytest -s tests/test_sin300.py
 

--- a/build_cell.py
+++ b/build_cell.py
@@ -1,5 +1,12 @@
-"""Build a cell and write it to build/gds/<cell_name>.gds."""
+"""Build a cell and write it to build/gds/<cell_name>.gds.
 
+When cell_name is "all_cells", builds every PDK-owned cell that can be
+instantiated with default arguments and packs them into a single GDS.
+Cells from installed packages (site-packages / .venv) and cells that
+require positional arguments are skipped automatically.
+"""
+
+import inspect
 import sys
 from pathlib import Path
 
@@ -8,5 +15,38 @@ from gdsfactoryplus.core.pdk import get_pdk, register_cells
 cell_name = sys.argv[1]
 Path("build/gds").mkdir(parents=True, exist_ok=True)
 register_cells()
-c = get_pdk().cells[cell_name]()
-c.write_gds(f"build/gds/{cell_name}.gds")
+pdk = get_pdk()
+
+if cell_name == "all_cells":
+    import gdsfactory as gf
+
+    c = gf.Component("all_cells")
+    for name, func in sorted(pdk.cells.items()):
+        # Skip cells from installed packages (not PDK-owned)
+        try:
+            src = inspect.getfile(func)
+        except TypeError:
+            continue
+        if ".venv" in src or "site-packages" in src:
+            continue
+
+        # Skip cells that require positional arguments
+        sig = inspect.signature(func)
+        required = [
+            p
+            for p in sig.parameters.values()
+            if p.default is inspect.Parameter.empty
+            and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+        ]
+        if required:
+            print(f"Skipping {name}: requires arguments {[p.name for p in required]}")
+            continue
+
+        try:
+            c.add_ref(func())
+        except Exception as e:  # noqa: BLE001
+            print(f"Error instantiating cell {name}: {e}")
+    c.write_gds(f"build/gds/{cell_name}.gds")
+else:
+    c = pdk.cells[cell_name]()
+    c.write_gds(f"build/gds/{cell_name}.gds")

--- a/cspdk/si220/cband/__init__.py
+++ b/cspdk/si220/cband/__init__.py
@@ -19,6 +19,12 @@ _cross_sections = get_cross_sections(tech)
 CONF.pdk = "cspdk.si220.cband"
 
 
+layer_transitions = {
+    LAYER.WG: cells.taper,
+    LAYER.PAD: cells.taper_metal,
+}
+
+
 @lru_cache
 def get_pdk() -> Pdk:
     """Return Cornerstone PDK."""
@@ -31,6 +37,7 @@ def get_pdk() -> Pdk:
         layer_views=LAYER_VIEWS,
         models=_models,
         routing_strategies=routing_strategies,
+        layer_transitions=layer_transitions,
     )
 
 

--- a/cspdk/si220/cband/samples/sample_routing.py
+++ b/cspdk/si220/cband/samples/sample_routing.py
@@ -1,0 +1,26 @@
+"""Sample routing two straights with different widths using layer_transitions."""
+
+import gdsfactory as gf
+
+from cspdk.si220.cband import PDK, cells, tech
+
+
+@gf.cell
+def sample_routing_different_widths() -> gf.Component:
+    """Route two straights with different widths to test auto-taper."""
+    c = gf.Component()
+    s1 = c << cells.straight(length=10, cross_section=tech.strip(width=0.4))
+    s2 = c << cells.straight(length=10, cross_section=tech.strip(width=1.0))
+    s2.dmove((100, 50))
+    tech.route_single(
+        c,
+        s1.ports["o2"],
+        s2.ports["o1"],
+    )
+    return c
+
+
+if __name__ == "__main__":
+    PDK.activate()
+    c = sample_routing_different_widths()
+    c.show()

--- a/cspdk/si220/oband/__init__.py
+++ b/cspdk/si220/oband/__init__.py
@@ -19,6 +19,12 @@ _cross_sections = get_cross_sections(tech)
 CONF.pdk = "cspdk.si220.oband"
 
 
+layer_transitions = {
+    LAYER.WG: cells.taper,
+    LAYER.PAD: cells.taper_metal,
+}
+
+
 @lru_cache
 def get_pdk() -> Pdk:
     """Return Cornerstone PDK."""
@@ -31,6 +37,7 @@ def get_pdk() -> Pdk:
         layer_views=LAYER_VIEWS,
         models=_models,
         routing_strategies=routing_strategies,
+        layer_transitions=layer_transitions,
     )
 
 

--- a/cspdk/si220/oband/samples/sample_routing.py
+++ b/cspdk/si220/oband/samples/sample_routing.py
@@ -1,0 +1,26 @@
+"""Sample routing two straights with different widths using layer_transitions."""
+
+import gdsfactory as gf
+
+from cspdk.si220.oband import PDK, cells, tech
+
+
+@gf.cell
+def sample_routing_different_widths() -> gf.Component:
+    """Route two straights with different widths to test auto-taper."""
+    c = gf.Component()
+    s1 = c << cells.straight(length=10, cross_section=tech.strip(width=0.4))
+    s2 = c << cells.straight(length=10, cross_section=tech.strip(width=1.0))
+    s2.dmove((100, 50))
+    tech.route_single(
+        c,
+        s1.ports["o2"],
+        s2.ports["o1"],
+    )
+    return c
+
+
+if __name__ == "__main__":
+    PDK.activate()
+    c = sample_routing_different_widths()
+    c.show()

--- a/cspdk/si500/__init__.py
+++ b/cspdk/si500/__init__.py
@@ -17,6 +17,11 @@ _cross_sections = get_cross_sections(tech)
 CONF.pdk = "cspdk.si500"
 
 
+layer_transitions = {
+    LAYER.WG: cells.taper,
+}
+
+
 @lru_cache
 def get_pdk() -> Pdk:
     """Return Cornerstone Si500 PDK."""
@@ -28,6 +33,7 @@ def get_pdk() -> Pdk:
         layer_stack=LAYER_STACK,
         layer_views=LAYER_VIEWS,
         routing_strategies=routing_strategies,
+        layer_transitions=layer_transitions,
     )
 
 

--- a/cspdk/si500/samples/sample_routing.py
+++ b/cspdk/si500/samples/sample_routing.py
@@ -1,0 +1,26 @@
+"""Sample routing two straights with different widths using layer_transitions."""
+
+import gdsfactory as gf
+
+from cspdk.si500 import PDK, cells, tech
+
+
+@gf.cell
+def sample_routing_different_widths() -> gf.Component:
+    """Route two straights with different widths to test auto-taper."""
+    c = gf.Component()
+    s1 = c << cells.straight(length=10, cross_section=tech.xs_rc(width=0.4))
+    s2 = c << cells.straight(length=10, cross_section=tech.xs_rc(width=1.0))
+    s2.dmove((100, 50))
+    tech.route_single(
+        c,
+        s1.ports["o2"],
+        s2.ports["o1"],
+    )
+    return c
+
+
+if __name__ == "__main__":
+    PDK.activate()
+    c = sample_routing_different_widths()
+    c.show()

--- a/cspdk/sin300/__init__.py
+++ b/cspdk/sin300/__init__.py
@@ -19,6 +19,11 @@ _cross_sections = get_cross_sections(tech)
 CONF.pdk = "cspdk.sin300"
 
 
+layer_transitions = {
+    LAYER.WG: cells.taper,
+}
+
+
 @lru_cache
 def get_pdk() -> Pdk:
     """Return Cornerstone SiN300 PDK."""
@@ -31,6 +36,7 @@ def get_pdk() -> Pdk:
         layer_views=LAYER_VIEWS,
         models=_models,
         routing_strategies=routing_strategies,
+        layer_transitions=layer_transitions,
     )
 
 

--- a/cspdk/sin300/samples/sample_routing.py
+++ b/cspdk/sin300/samples/sample_routing.py
@@ -1,0 +1,26 @@
+"""Sample routing two straights with different widths using layer_transitions."""
+
+import gdsfactory as gf
+
+from cspdk.sin300 import PDK, cells, tech
+
+
+@gf.cell
+def sample_routing_different_widths() -> gf.Component:
+    """Route two straights with different widths to test auto-taper."""
+    c = gf.Component()
+    s1 = c << cells.straight(length=10, cross_section=tech.xs_nc(width=0.8))
+    s2 = c << cells.straight(length=10, cross_section=tech.xs_nc(width=1.5))
+    s2.dmove((100, 50))
+    tech.route_single(
+        c,
+        s1.ports["o2"],
+        s2.ports["o1"],
+    )
+    return c
+
+
+if __name__ == "__main__":
+    PDK.activate()
+    c = sample_routing_different_widths()
+    c.show()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -20,4 +20,7 @@ def test_sample_routing_different_widths(pdk_module: str, sample_module: str) ->
     pdk.PDK.activate()
     sample = importlib.import_module(sample_module)
     c = sample.sample_routing_different_widths()
-    assert c.ports, "Component should have ports"
+    # Two straights + route instances; more than 2 means tapers were inserted
+    assert len(c.insts) > 2, (
+        f"Expected tapers to be inserted, got only {len(c.insts)} instances"
+    )

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,23 @@
+"""Test routing with layer_transitions and auto-taper."""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "pdk_module,sample_module",
+    [
+        ("cspdk.si220.cband", "cspdk.si220.cband.samples.sample_routing"),
+        ("cspdk.si220.oband", "cspdk.si220.oband.samples.sample_routing"),
+        ("cspdk.si500", "cspdk.si500.samples.sample_routing"),
+        ("cspdk.sin300", "cspdk.sin300.samples.sample_routing"),
+    ],
+)
+def test_sample_routing_different_widths(pdk_module: str, sample_module: str) -> None:
+    """Test that routing two straights with different widths works."""
+    import importlib
+
+    pdk = importlib.import_module(pdk_module)
+    pdk.PDK.activate()
+    sample = importlib.import_module(sample_module)
+    c = sample.sample_routing_different_widths()
+    assert c.ports, "Component should have ports"


### PR DESCRIPTION
## Summary
- Add `layer_transitions` to all PDK variants (si220 cband, si220 oband, si500, sin300)
- Map `LAYER.WG` to `cells.taper` for waveguide width transitions
- Map `LAYER.PAD` to `cells.taper_metal` for metal width transitions (si220 cband/oband only, as si500 and sin300 lack a `taper_metal` cell)

## Test plan
- [ ] Verify each PDK variant activates without errors
- [ ] Test routing with auto-taper between different waveguide widths

## Summary by Sourcery

Add layer transition mappings to all Cornerstone PDK variants to support automatic waveguide and metal width transitions during routing.

New Features:
- Introduce layer transition configuration for waveguide layers across si220 cband, si220 oband, si500, and sin300 PDKs.
- Enable PAD-to-metal taper transitions for si220 cband and oband PDKs where metal taper cells are available.

Enhancements:
- Wire the new layer transition mappings into each PDK factory so routing can automatically insert appropriate taper cells between differing widths.