### PR TITLE
Grating LayerStack logic

### DIFF
--- a/cspdk/si220/cband/tech.py
+++ b/cspdk/si220/cband/tech.py
@@ -54,6 +54,7 @@ LAYER = LayerMapCornerstone
 def get_layer_stack(
     thickness_wg: float = 220 * nm,
     thickness_slab: float = 100 * nm,
+    thickness_grating: float = 150 * nm,
     zmin_heater: float = 1.1,
     thickness_heater: float = 700 * nm,
     zmin_metal: float = 1.1,
@@ -66,6 +67,7 @@ def get_layer_stack(
     Args:
         thickness_wg: waveguide thickness in um.
         thickness_slab: slab thickness in um.
+        thickness_grating: DUV grating residual Si thickness in um (220nm - 70nm etch).
         zmin_heater: TiN heater.
         thickness_heater: TiN thickness.
         zmin_metal: metal thickness in um.
@@ -82,6 +84,16 @@ def get_layer_stack(
                 sidewall_angle=10,
                 width_to_z=0.5,
                 derived_layer=LogicalLayer(layer=LAYER.WG),
+            ),
+            grating=LayerLevel(
+                layer=LogicalLayer(layer=LAYER.WG) & LogicalLayer(layer=LAYER.GRA),
+                thickness=thickness_grating,
+                zmin=0.0,
+                material="si",
+                info={"mesh_order": 1},
+                sidewall_angle=10,
+                width_to_z=0.5,
+                derived_layer=LogicalLayer(layer=LAYER.GRA),
             ),
             slab=LayerLevel(
                 layer=LogicalLayer(layer=LAYER.SLAB),

--- a/cspdk/si220/oband/tech.py
+++ b/cspdk/si220/oband/tech.py
@@ -54,6 +54,7 @@ LAYER = LayerMapCornerstone
 def get_layer_stack(
     thickness_wg: float = 220 * nm,
     thickness_slab: float = 100 * nm,
+    thickness_grating: float = 150 * nm,
     zmin_heater: float = 1.1,
     thickness_heater: float = 700 * nm,
     zmin_metal: float = 1.1,
@@ -61,11 +62,12 @@ def get_layer_stack(
 ) -> LayerStack:
     """Returns LayerStack.
 
-    based on paper https://www.degruyter.com/document/doi/10.1515/nanoph-2013-0034/html
+    based on Cornerstone Si_220nm_passive process_overview.yaml
 
     Args:
         thickness_wg: waveguide thickness in um.
         thickness_slab: slab thickness in um.
+        thickness_grating: DUV grating residual Si thickness in um (220nm - 70nm etch).
         zmin_heater: TiN heater.
         thickness_heater: TiN thickness.
         zmin_metal: metal thickness in um.
@@ -74,13 +76,24 @@ def get_layer_stack(
     return LayerStack(
         layers=dict(
             core=LayerLevel(
-                layer=LogicalLayer(layer=LAYER.WG),
+                layer=LogicalLayer(layer=LAYER.WG) - LogicalLayer(layer=LAYER.GRA),
                 thickness=thickness_wg,
                 zmin=0.0,
                 material="si",
                 info={"mesh_order": 1},
                 sidewall_angle=10,
                 width_to_z=0.5,
+                derived_layer=LogicalLayer(layer=LAYER.WG),
+            ),
+            grating=LayerLevel(
+                layer=LogicalLayer(layer=LAYER.WG) & LogicalLayer(layer=LAYER.GRA),
+                thickness=thickness_grating,
+                zmin=0.0,
+                material="si",
+                info={"mesh_order": 1},
+                sidewall_angle=10,
+                width_to_z=0.5,
+                derived_layer=LogicalLayer(layer=LAYER.GRA),
             ),
             slab=LayerLevel(
                 layer=LogicalLayer(layer=LAYER.SLAB),


### PR DESCRIPTION
Closes #253 by adding a grating LayerLevel (WG&GRA, 0.15µm Si, derived_layer=GRA) and switching core to WG-GRA in both cband and oband tech.py, so grating-coupler geometry survives get_component_with_derived_layers and renders/simulates correctly.

## Summary by Sourcery

Define a dedicated grating LayerLevel in the Si220 Cornerstone layer stacks and adjust core waveguide layers so grating regions are modeled correctly in both O-band and C-band technologies.

New Features:
- Add a configurable grating silicon thickness parameter to the Si220 O-band and C-band layer stack definitions.
- Introduce an explicit grating LayerLevel tied to the grating logical layer in both O-band and C-band tech configurations.

Enhancements:
- Update the core waveguide LayerLevel in the O-band tech configuration so it excludes grating regions and uses a derived waveguide layer for layer derivation workflows.
- Refresh the O-band layer stack documentation string to reference the Cornerstone process overview specification.