### PR TITLE
feat: add tool.elvis config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,13 @@ docs = ["jupytext", "matplotlib", "jupyter-book>=0.15.1,<1.1", "gsim; python_ver
 [tool.codespell]
 ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, schem"
 
+[tool.elvis]
+connected-layers = [[[39, 0], [41, 0]]]
+short-layers = [[39, 0], [41, 0]]
+
+[tool.elvis.equivalent-ports]
+pad = ["e1", "e2", "e3", "e4", "pad"]
+
 [tool.gdsfactoryplus]
 name = "cspdk.si220.cband"
 
@@ -58,14 +65,6 @@ options = ["cspdk.si220.cband", "cspdk.si220.oband", "cspdk.si500", "cspdk.sin30
 max = 1.6
 min = 1.5
 num = 1000
-
-
-[tool.elvis]
-short-layers = [[39, 0], [41, 0]]
-connected-layers = [[[39, 0], [41, 0]]]
-
-[tool.elvis.equivalent-ports]
-pad = ["e1", "e2", "e3", "e4", "pad"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,14 @@ max = 1.6
 min = 1.5
 num = 1000
 
+
+[tool.elvis]
+short-layers = [[39, 0], [41, 0]]
+connected-layers = [[[39, 0], [41, 0]]]
+
+[tool.elvis.equivalent-ports]
+pad = ["e1", "e2", "e3", "e4", "pad"]
+
 [tool.mypy]
 python_version = "3.10"
 strict = true


### PR DESCRIPTION
## Summary
- Add `[tool.elvis]` section to `pyproject.toml` with `short-layers` and `connected-layers` derived from the PDK's tech.py connectivity definitions
- Add `[tool.elvis.equivalent-ports]` for pad cells where applicable

## Test plan
- [x] Verify layer tuples match the PDK's layer definitions
- [x] Verify connected-layers pairs are correct