### PR TITLE
Add zensical docs support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,28 @@ jupytext:
 notebooks:
 	jupytext docs/**/*.py --to ipynb
 
-docs:
+docs-pdf:
 	uv run python .github/write_cells_si220_cband.py
+	uv run python .github/write_cells_si220_oband.py
 	uv run python .github/write_cells_si500.py
 	uv run python .github/write_cells_sin300.py
-	uv run jb build docs
+	cp CHANGELOG.md docs/changelog.md
+	uv run mkdocs build -f mkdocs-pdf.yml
 
-.PHONY: drc doc docs
+docs:
+	uv run python .github/write_cells_si220_cband.py
+	uv run python .github/write_cells_si220_oband.py
+	uv run python .github/write_cells_si500.py
+	uv run python .github/write_cells_sin300.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical build
+
+docs-serve:
+	uv run python .github/write_cells_si220_cband.py
+	uv run python .github/write_cells_si220_oband.py
+	uv run python .github/write_cells_si500.py
+	uv run python .github/write_cells_sin300.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical serve -a localhost:8080
+
+.PHONY: drc drc-sample doc docs docs-pdf build

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,54 @@
+# ruff: noqa: INP001
+"""Post-process notebook markdown: convert MyST admonitions to Material style.
+
+Usage: python docs/hooks.py docs/notebooks/*.md
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def process(markdown: str) -> str:
+    """Apply all transformations to a markdown string."""
+    return _myst_to_material_admonitions(markdown)
+
+
+def _myst_to_material_admonitions(markdown: str) -> str:
+    r"""Convert MyST ```{type}\n...\n``` to Material !!! type\n\n    ..."""
+
+    def _replace(match: re.Match[str]) -> str:
+        kind = match.group(1)
+        body = match.group(2)
+        lines = body.splitlines()
+        title = ""
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        if lines and (m := re.match(r"^#+ +(.+)", lines[0])):
+            title = m.group(1)
+            lines.pop(0)
+        non_empty = [line for line in lines if line.strip()]
+        min_indent = min(
+            (len(line) - len(line.lstrip()) for line in non_empty), default=0
+        )
+        out = []
+        for line in lines:
+            if line.strip():
+                out.append("    " + line[min_indent:])
+            else:
+                out.append("")
+        header = f'!!! {kind} "{title}"' if title else f"!!! {kind}"
+        return header + "\n\n" + "\n".join(out).rstrip() + "\n"
+
+    return re.sub(
+        r"^```\{(\w+)\}\s*\n(.*?)^```\s*$",
+        _replace,
+        markdown,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+
+
+if __name__ == "__main__":
+    for path in sys.argv[1:]:
+        p = Path(path)
+        p.write_text(process(p.read_text()))

--- a/mkdocs-pdf.yml
+++ b/mkdocs-pdf.yml
@@ -1,0 +1,24 @@
+site_name: CornerStone PDK
+docs_dir: docs
+site_dir: build/pdf
+nav:
+  - Home: index.md
+  - Reference:
+      - Changelog: changelog.md
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_root_toc_entry: false
+            show_source: false
+  - with-pdf:
+      author: GDSFactory
+      cover_subtitle: Photonics Process Design Kit
+      output_path: ../../docs.pdf
+theme:
+  name: material
+  logo: logo.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,14 @@ dev = [
   "gdsfactoryplus",
   "towncrier"
 ]
-docs = ["jupytext", "matplotlib", "jupyter-book>=0.15.1,<1.1", "gsim; python_version>='3.12'"]
+docs = [
+  "jupyter",
+  "mkdocs-material",
+  "mkdocs-with-pdf",
+  "nbconvert",
+  "mkdocstrings[python]>=0.27.0",
+  "zensical>=0.0.40,<0.1.0"
+]
 
 [tool.codespell]
 ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, schem"

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,27 @@
+[project]
+nav = [
+  {"Home" = "index.md"},
+  {"Reference" = [
+    {"Changelog" = "changelog.md"}
+  ]}
+]
+site_dir = "docs/_build/html"
+site_name = "CornerStone PDK"
+site_url = "https://gdsfactory.github.io/cspdk"
+
+[project.plugins.autorefs]
+
+[project.plugins.mkdocstrings]
+
+[project.plugins.mkdocstrings.handlers.python]
+
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+show_root_toc_entry = false
+show_source = false
+
+[project.plugins.search]
+
+[project.theme]
+logo = "logo.png"
+name = "material"


### PR DESCRIPTION
## Summary
- Switch documentation to zensical (Material theme) with mkdocs-pdf support
- Update Makefile with `docs`, `docs-serve`, and `docs-pdf` targets

## Test plan
- [ ] `make docs` builds HTML documentation
- [ ] `make docs-pdf` generates PDF

## Summary by Sourcery

Switch project documentation to a Zensical/MkDocs Material setup with PDF generation support and corresponding Makefile targets.

New Features:
- Add Zensical/MkDocs Material configuration for HTML documentation, including navigation and theme settings.
- Introduce MkDocs-based PDF documentation build pipeline with Material theme and with-pdf plugin.

Enhancements:
- Update Makefile docs targets to use Zensical/MkDocs tooling and generate changelog documentation from the project CHANGELOG.
- Add a documentation hook to convert MyST-style admonitions into MkDocs Material admonition syntax for notebook-derived markdown.

Build:
- Extend docs extra dependencies in pyproject.toml to include MkDocs Material, mkdocs-with-pdf, mkdocstrings, Zensical, and related tooling.