### PR TITLE
Strip hyperlinks from changelog in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ docs-pdf:
 	uv run python .github/write_cells_si220_oband.py
 	uv run python .github/write_cells_si500.py
 	uv run python .github/write_cells_sin300.py
-	cp CHANGELOG.md docs/changelog.md
+	uv run python -c "import re; from pathlib import Path; t=Path('CHANGELOG.md').read_text(); Path('docs/changelog.md').write_text(re.sub(r'\[([^\]]*)\]\([^)]*\)', r'\1', t))"
 	uv run mkdocs build -f mkdocs-pdf.yml
 
 docs:
@@ -60,7 +60,7 @@ docs:
 	uv run python .github/write_cells_si220_oband.py
 	uv run python .github/write_cells_si500.py
 	uv run python .github/write_cells_sin300.py
-	cp CHANGELOG.md docs/changelog.md
+	uv run python -c "import re; from pathlib import Path; t=Path('CHANGELOG.md').read_text(); Path('docs/changelog.md').write_text(re.sub(r'\[([^\]]*)\]\([^)]*\)', r'\1', t))"
 	uv run --extra docs zensical build
 
 docs-serve:
@@ -68,7 +68,7 @@ docs-serve:
 	uv run python .github/write_cells_si220_oband.py
 	uv run python .github/write_cells_si500.py
 	uv run python .github/write_cells_sin300.py
-	cp CHANGELOG.md docs/changelog.md
+	uv run python -c "import re; from pathlib import Path; t=Path('CHANGELOG.md').read_text(); Path('docs/changelog.md').write_text(re.sub(r'\[([^\]]*)\]\([^)]*\)', r'\1', t))"
 	uv run --extra docs zensical serve -a localhost:8080
 
 .PHONY: drc drc-sample doc docs docs-pdf build


### PR DESCRIPTION
## Summary
- Replace `cp CHANGELOG.md docs/changelog.md` with a Python one-liner that strips `[text](url)` → `text`
- Matches the CI "Sync changelog" step in pdk-ci-workflow
- Fixes broken/stale hyperlinks in rendered docs changelog

## Test plan
- [ ] Verify `make docs` produces `docs/changelog.md` without hyperlinks

## Summary by Sourcery

Enhancements:
- Replace direct copying of CHANGELOG.md with a scripted step that removes Markdown link syntax before writing docs/changelog.md.