### PR TITLE
Replace RST code directives with markdown code blocks

### DIFF
--- a/cspdk/si220/cband/cells/rings.py
+++ b/cspdk/si220/cband/cells/rings.py
@@ -33,8 +33,7 @@ def ring_single(
         bend: bend type for the ring. Defaults to "bend_euler".
         p: percentage of the bend that is euler. 1 means full euler, 0 means full circular.
 
-    .. code::
-
+    ```
                     xxxxxxxxxxxxx
                 xxxxx           xxxx
               xxx                   xxx
@@ -52,6 +51,7 @@ def ring_single(
                 xxx──────▲─────────xxx
                          │gap
                  o1──────▼─────────o2
+    ```
     """
     return gf.c.ring_single(
         gap=gap,

--- a/cspdk/si220/cband/tech.py
+++ b/cspdk/si220/cband/tech.py
@@ -161,11 +161,11 @@ def xsection(func: Callable[..., CrossSection]) -> Callable[..., CrossSection]:
 
     Ensures that the cross-section name matches the name of the function that generated it when created using default parameters
 
-    .. code-block:: python
-
+    ```python
         @xsection
         def strip(width=TECH.width_strip, radius=TECH.radius_strip):
             return gf.cross_section.cross_section(width=width, radius=radius)
+    ```
     """
     default_xs = func()
     _cross_section_default_names[default_xs.name] = func.__name__

--- a/cspdk/si220/oband/cells/rings.py
+++ b/cspdk/si220/oband/cells/rings.py
@@ -31,8 +31,7 @@ def ring_single(
         bend: bend type for the ring. Defaults to "bend_euler".
         p: percentage of the bend that is euler. 1 means full euler, 0 means full circular.
 
-    .. code::
-
+    ```
                     xxxxxxxxxxxxx
                 xxxxx           xxxx
               xxx                   xxx
@@ -50,6 +49,7 @@ def ring_single(
                 xxx──────▲─────────xxx
                          │gap
                  o1──────▼─────────o2
+    ```
     """
     return gf.c.ring_single(
         gap=gap,

--- a/cspdk/si220/oband/tech.py
+++ b/cspdk/si220/oband/tech.py
@@ -160,11 +160,11 @@ def xsection(func: Callable[..., CrossSection]) -> Callable[..., CrossSection]:
 
     Ensures that the cross-section name matches the name of the function that generated it when created using default parameters
 
-    .. code-block:: python
-
+    ```python
         @xsection
         def strip(width=TECH.width_strip, radius=TECH.radius_strip):
             return gf.cross_section.cross_section(width=width, radius=radius)
+    ```
     """
     default_xs = func()
     _cross_section_default_names[default_xs.name] = func.__name__


### PR DESCRIPTION
## Summary

- Replace `.. code::` and `.. code-block:: python` RST directives with markdown triple-backtick code blocks in docstrings
- ASCII art diagrams and code examples were not rendering correctly with the new docs theme because it expects markdown, not RST

## Test plan

- [ ] Verify docs build correctly
- [ ] Check ASCII art diagrams render properly in the docs

## Summary by Sourcery

Documentation:
- Replace RST code and code-block directives in docstrings with markdown triple-backtick code blocks so ASCII diagrams and Python examples render correctly.