### PR TITLE
Bump doroutes dependency to ~=1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
   "gdsfactory~=9.43.0",
   "gplugins[sax,femwell,tidy3d]~=2.1.0",
-  "doroutes~=0.6.0"
+  "doroutes~=1.0.0"
 ]
 description = "CornerStone PDK"
 keywords = ["python"]


### PR DESCRIPTION
## Summary
- Updates doroutes dependency from `~=0.6.0` to `~=1.0.0`
- Closes #266

## Test plan
- [ ] Verify DoRoutes 1.0.0 is published
- [ ] Run PDK tests after updating