### PR TITLE
Add sample project for centralized CI testing

### DIFF
--- a/.github/workflows/sample-projects.yml
+++ b/.github/workflows/sample-projects.yml
@@ -1,0 +1,12 @@
+name: Test Sample Projects
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test-sample-projects:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test-sample-projects.yml@main
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/cspdk--sample-projects/basic/mycspdk/__init__.py
+++ b/cspdk--sample-projects/basic/mycspdk/__init__.py
@@ -1,0 +1,3 @@
+"""Basic cspdk sample project."""
+
+__version__ = "0.1.0"

--- a/cspdk--sample-projects/basic/mycspdk/samples/__init__.py
+++ b/cspdk--sample-projects/basic/mycspdk/samples/__init__.py
@@ -1,0 +1,1 @@
+"""Sample cells using cspdk."""

--- a/cspdk--sample-projects/basic/mycspdk/samples/sample0.py
+++ b/cspdk--sample-projects/basic/mycspdk/samples/sample0.py
@@ -1,0 +1,24 @@
+"""Sample cell: routed MZI using cspdk si220 C-band."""
+
+import gdsfactory as gf
+
+from cspdk.si220.cband import cells, tech
+
+
+@gf.cell
+def sample0_routed_mzi() -> gf.Component:
+    """Create two straights connected by a route."""
+    c = gf.Component()
+    s1 = c << cells.straight(length=10)
+    s2 = c << cells.straight(length=10)
+    s2.dmove((100, 50))
+    tech.route_single(c, s1.ports["o2"], s2.ports["o1"])
+    return c
+
+
+if __name__ == "__main__":
+    from cspdk.si220.cband import PDK
+
+    PDK.activate()
+    c = sample0_routed_mzi()
+    c.show()

--- a/cspdk--sample-projects/basic/pyproject.toml
+++ b/cspdk--sample-projects/basic/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"
+requires = ["setuptools>=68.0"]
 
 [project]
 name = "cspdk-sample-basic"
@@ -10,7 +10,7 @@ requires-python = ">=3.12"
 dependencies = ["cspdk"]
 
 [dependency-groups]
-dev = ["pytest"]
+dev = ["gdsfactoryplus", "pytest"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/cspdk--sample-projects/basic/pyproject.toml
+++ b/cspdk--sample-projects/basic/pyproject.toml
@@ -6,21 +6,11 @@ requires = ["setuptools>=68.0"]
 dev = ["gdsfactoryplus", "pytest"]
 
 [project]
-name = "mycspdk"
-version = "0.1.0"
-description = "Basic sample project for cspdk"
-requires-python = ">=3.12"
 dependencies = ["cspdk"]
-
-[tool.gdsfactoryplus]
-name = "cspdk.si220.cband"
-
-[tool.gdsfactoryplus.drc]
-pdk = "cspdk.si220.cband"
-timeout = 300
-
-[tool.gdsfactoryplus.pdk]
-name = "cspdk.si220.cband"
+description = "Basic sample project for cspdk"
+name = "mycspdk"
+requires-python = ">=3.12"
+version = "0.1.0"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/cspdk--sample-projects/basic/pyproject.toml
+++ b/cspdk--sample-projects/basic/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cspdk-sample-basic"
+version = "0.1.0"
+description = "Basic sample project for cspdk"
+requires-python = ">=3.12"
+dependencies = ["cspdk"]
+
+[dependency-groups]
+dev = ["pytest"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/cspdk--sample-projects/basic/pyproject.toml
+++ b/cspdk--sample-projects/basic/pyproject.toml
@@ -2,15 +2,32 @@
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>=68.0"]
 
+[dependency-groups]
+dev = ["gdsfactoryplus", "pytest"]
+
 [project]
-name = "cspdk-sample-basic"
+name = "mycspdk"
 version = "0.1.0"
 description = "Basic sample project for cspdk"
 requires-python = ">=3.12"
 dependencies = ["cspdk"]
 
-[dependency-groups]
-dev = ["gdsfactoryplus", "pytest"]
+[tool.gdsfactoryplus]
+name = "cspdk.si220.cband"
+
+[tool.gdsfactoryplus.drc]
+pdk = "cspdk.si220.cband"
+timeout = 300
+
+[tool.gdsfactoryplus.pdk]
+name = "cspdk.si220.cband"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.setuptools.package-data]
+"*" = ["*.csv", "*.gds", "*.lyp", "*.oas", "*.yaml", "*.yml"]
+
+[tool.setuptools.packages.find]
+include = ["mycspdk*"]
+where = ["."]

--- a/cspdk--sample-projects/basic/tests/__init__.py
+++ b/cspdk--sample-projects/basic/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Basic sample project tests for cspdk."""

--- a/cspdk--sample-projects/basic/tests/test_basic.py
+++ b/cspdk--sample-projects/basic/tests/test_basic.py
@@ -1,0 +1,71 @@
+"""Basic tests for cspdk.
+
+These tests verify that cspdk imports correctly, the PDK can be activated,
+and fundamental components can be created without requiring simulation or
+API keys.
+"""
+
+import gdsfactory as gf
+from cspdk.si220.cband import PDK, cells, tech
+
+
+def test_import():
+    """Verify that cspdk and its submodules import without errors."""
+    import cspdk
+    import cspdk.si220.cband
+
+    assert cspdk is not None
+    assert cspdk.si220.cband is not None
+
+
+def test_pdk_activation():
+    """Verify that the si220 C-band PDK activates correctly."""
+    PDK.activate()
+    assert gf.get_active_pdk().name == "cspdk.si220.cband"
+
+
+def test_cell_creation():
+    """Create a basic straight waveguide and verify it is a valid component."""
+    c = cells.straight(length=10)
+    assert isinstance(c, gf.Component)
+    assert len(c.ports) > 0
+
+
+def test_multiple_cells():
+    """Create several different cell types and verify each is a valid component."""
+    coupler = cells.coupler()
+    assert isinstance(coupler, gf.Component)
+    assert len(coupler.ports) > 0
+
+    mmi = cells.mmi1x2()
+    assert isinstance(mmi, gf.Component)
+    assert len(mmi.ports) > 0
+
+    bend = cells.bend_euler()
+    assert isinstance(bend, gf.Component)
+    assert len(bend.ports) > 0
+
+
+def test_routing():
+    """Create a simple routed component connecting two straights."""
+
+    @gf.cell
+    def routed_mzi():
+        c = gf.Component()
+        s1 = c << cells.straight(length=10)
+        s2 = c << cells.straight(length=10)
+        s2.dmove((100, 50))
+        tech.route_single(c, s1.ports["o2"], s2.ports["o1"])
+        return c
+
+    c = routed_mzi()
+    assert isinstance(c, gf.Component)
+    assert len(c.ports) > 0
+
+
+def test_component_ports():
+    """Verify that a straight waveguide has the expected input/output ports."""
+    c = cells.straight(length=10)
+    port_names = [p.name for p in c.ports]
+    assert "o1" in port_names, f"Expected port 'o1', found {port_names}"
+    assert "o2" in port_names, f"Expected port 'o2', found {port_names}"

--- a/cspdk--sample-projects/basic/tests/test_basic.py
+++ b/cspdk--sample-projects/basic/tests/test_basic.py
@@ -6,6 +6,7 @@ API keys.
 """
 
 import gdsfactory as gf
+
 from cspdk.si220.cband import PDK, cells, tech
 
 


### PR DESCRIPTION
## Summary
- Adds `cspdk--sample-projects/basic/` — a minimal sample project that the centralized `doplaydo/pdk-ci-workflow` test-sample-projects workflow can discover and test
- Sample project tests: PDK import, activation, cell creation (straight, coupler, mmi1x2, bend_euler), routing, and port validation
- Adds `.github/workflows/sample-projects.yml` caller workflow

The sample project depends on `cspdk` and runs 6 basic smoke tests to verify the PDK works when installed as a dependency.

## Test plan
- [x] Discovery command finds the sample project: `find . -maxdepth 3 -name 'pyproject.toml' -path '*--sample-projects/*'`
- [ ] CI sample-projects workflow discovers and tests the project
- [ ] Tests pass in CI with `gfp test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a basic sample project and CI workflow to validate cspdk as a consumable dependency.

New Features:
- Introduce a minimal cspdk sample project with pytest-based smoke tests for core PDK functionality.
- Add tests that cover PDK import, activation, basic cell creation, routing, and port validation.

CI:
- Add a reusable GitHub Actions workflow to run centralized test-sample-projects CI against sample projects.