### PR TITLE
Add kwasm viewers to cell docs and fix index.md

### DIFF
--- a/.github/write_cells_si220_cband.py
+++ b/.github/write_cells_si220_cband.py
@@ -1,17 +1,71 @@
-"""Write docs."""
+"""Write cell docs as Markdown with kwasm viewers."""
 
+import base64
 import inspect
+import traceback
 
+import kwasm.embed
+import matplotlib
+import matplotlib.pyplot as plt
+from gdsfactory.serialization import clean_value_json
+
+matplotlib.use("Agg")
+
+from cspdk.si220.cband import PDK
 from cspdk.si220.cband import _cells as cells
 from cspdk.si220.cband.config import PATH
 
+PDK.activate()
+
 filepath = PATH.repo / "docs" / "cells_si220_cband.md"
+kwasm_dir = PATH.repo / "docs" / "kwasm"
+gds_dir = kwasm_dir / "gds"
 
 skip = {}
-
 skip_plot: tuple[str, ...] = ("",)
 skip_settings: tuple[str, ...] = ()
 
+
+def _setup_kwasm_viewer() -> None:
+    gds_dir.mkdir(parents=True, exist_ok=True)
+    viewer_path = kwasm_dir / "viewer.html"
+    if viewer_path.exists():
+        return
+    template = kwasm.embed._read_artifacts()
+    template = template.replace("KWASM_GDS_B64", "")
+    lyp_path = PATH.lyp
+    if lyp_path.exists():
+        lyp_b64 = base64.b64encode(lyp_path.read_bytes()).decode("ascii")
+        template = template.replace("KWASM_LYP_B64", lyp_b64)
+    else:
+        template = template.replace("KWASM_LYP_B64", "")
+    template = template.replace("KWASM_LYRDB_B64", "")
+    template = template.replace("KWASM_NETLIST_B64", "")
+    viewer_path.write_text(template)
+
+
+def _write_gds(name: str) -> bool:
+    try:
+        sig = inspect.signature(cells[name])
+        defaults = {}
+        for p in sig.parameters:
+            v = sig.parameters[p].default
+            if isinstance(v, int | float | str | tuple):
+                defaults[p] = v
+        c = cells[name](**defaults)
+        c.write(str(gds_dir / f"{name}.gds"))
+        c.plot()
+        plt.savefig(str(gds_dir / f"{name}.png"), dpi=150, bbox_inches="tight")
+        plt.close("all")
+    except Exception:
+        traceback.print_exc()
+        plt.close("all")
+        return False
+    else:
+        return True
+
+
+_setup_kwasm_viewer()
 
 with open(filepath, "w+") as f:
     f.write("# Cells Si SOI 220nm Cband\n\n")
@@ -23,40 +77,28 @@ with open(filepath, "w+") as f:
         sig = inspect.signature(cells[name])
         kwargs = ", ".join(
             [
-                f"{p}={repr(sig.parameters[p].default)}"
+                f"{p}={clean_value_json(sig.parameters[p].default)!r}"
                 for p in sig.parameters
                 if isinstance(sig.parameters[p].default, int | float | str | tuple)
                 and p not in skip_settings
             ]
         )
-        if name in skip_plot:
-            f.write(
-                f"""
+        f.write(f"## {name}\n\n")
+        f.write(f"::: cspdk.si220.cband.cells.{name}\n   :noindex:\n\n")
+        if name not in skip_plot:
+            has_gds = _write_gds(name)
+            if has_gds:
+                f.write(f"![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write(
+                    f'<iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
+                    f' loading="lazy" width="100%" height="400"'
+                    f' style="border:none"></iframe>\n\n'
+                )
+            f.write("```python\n")
+            f.write("import cspdk\n\n")
+            f.write(f"c = cspdk.si220.cband.cells.{name}({kwargs}).copy()\n")
+            f.write("c.draw_ports()\n")
+            f.write("c.plot()\n")
+            f.write("```\n\n")
 
-## {name}
-
-
-::: cspdk.si220.cband.cells.{name}
-   :noindex:
-
-"""
-            )
-        else:
-            f.write(
-                f"""
-
-## {name}
-
-
-::: cspdk.si220.cband.cells.{name}
-   :noindex:
-
-```python
-import cspdk
-
-c = cspdk.si220.cband.cells.{name}({kwargs}).copy()
-c.draw_ports()
-c.plot()
-```
-"""
-            )
+print(f"Wrote {filepath}")

--- a/.github/write_cells_si220_oband.py
+++ b/.github/write_cells_si220_oband.py
@@ -1,17 +1,71 @@
-"""Write docs."""
+"""Write cell docs as Markdown with kwasm viewers."""
 
+import base64
 import inspect
+import traceback
 
+import kwasm.embed
+import matplotlib
+import matplotlib.pyplot as plt
+from gdsfactory.serialization import clean_value_json
+
+matplotlib.use("Agg")
+
+from cspdk.si220.oband import PDK
 from cspdk.si220.oband import _cells as cells
 from cspdk.si220.oband.config import PATH
 
+PDK.activate()
+
 filepath = PATH.repo / "docs" / "cells_si220_oband.md"
+kwasm_dir = PATH.repo / "docs" / "kwasm"
+gds_dir = kwasm_dir / "gds"
 
 skip = {}
-
 skip_plot: tuple[str, ...] = ("",)
 skip_settings: tuple[str, ...] = ()
 
+
+def _setup_kwasm_viewer() -> None:
+    gds_dir.mkdir(parents=True, exist_ok=True)
+    viewer_path = kwasm_dir / "viewer.html"
+    if viewer_path.exists():
+        return
+    template = kwasm.embed._read_artifacts()
+    template = template.replace("KWASM_GDS_B64", "")
+    lyp_path = PATH.lyp
+    if lyp_path.exists():
+        lyp_b64 = base64.b64encode(lyp_path.read_bytes()).decode("ascii")
+        template = template.replace("KWASM_LYP_B64", lyp_b64)
+    else:
+        template = template.replace("KWASM_LYP_B64", "")
+    template = template.replace("KWASM_LYRDB_B64", "")
+    template = template.replace("KWASM_NETLIST_B64", "")
+    viewer_path.write_text(template)
+
+
+def _write_gds(name: str) -> bool:
+    try:
+        sig = inspect.signature(cells[name])
+        defaults = {}
+        for p in sig.parameters:
+            v = sig.parameters[p].default
+            if isinstance(v, int | float | str | tuple):
+                defaults[p] = v
+        c = cells[name](**defaults)
+        c.write(str(gds_dir / f"{name}.gds"))
+        c.plot()
+        plt.savefig(str(gds_dir / f"{name}.png"), dpi=150, bbox_inches="tight")
+        plt.close("all")
+    except Exception:
+        traceback.print_exc()
+        plt.close("all")
+        return False
+    else:
+        return True
+
+
+_setup_kwasm_viewer()
 
 with open(filepath, "w+") as f:
     f.write("# Cells Si SOI 220nm Oband\n\n")
@@ -23,40 +77,28 @@ with open(filepath, "w+") as f:
         sig = inspect.signature(cells[name])
         kwargs = ", ".join(
             [
-                f"{p}={repr(sig.parameters[p].default)}"
+                f"{p}={clean_value_json(sig.parameters[p].default)!r}"
                 for p in sig.parameters
                 if isinstance(sig.parameters[p].default, int | float | str | tuple)
                 and p not in skip_settings
             ]
         )
-        if name in skip_plot:
-            f.write(
-                f"""
+        f.write(f"## {name}\n\n")
+        f.write(f"::: cspdk.si220.oband.cells.{name}\n   :noindex:\n\n")
+        if name not in skip_plot:
+            has_gds = _write_gds(name)
+            if has_gds:
+                f.write(f"![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write(
+                    f'<iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
+                    f' loading="lazy" width="100%" height="400"'
+                    f' style="border:none"></iframe>\n\n'
+                )
+            f.write("```python\n")
+            f.write("import cspdk\n\n")
+            f.write(f"c = cspdk.si220.oband.cells.{name}({kwargs}).copy()\n")
+            f.write("c.draw_ports()\n")
+            f.write("c.plot()\n")
+            f.write("```\n\n")
 
-## {name}
-
-
-::: cspdk.si220.oband.cells.{name}
-   :noindex:
-
-"""
-            )
-        else:
-            f.write(
-                f"""
-
-## {name}
-
-
-::: cspdk.si220.oband.cells.{name}
-   :noindex:
-
-```python
-import cspdk
-
-c = cspdk.si220.oband.cells.{name}({kwargs}).copy()
-c.draw_ports()
-c.plot()
-```
-"""
-            )
+print(f"Wrote {filepath}")

--- a/.github/write_cells_si500.py
+++ b/.github/write_cells_si500.py
@@ -1,17 +1,71 @@
-"""Write docs."""
+"""Write cell docs as Markdown with kwasm viewers."""
 
+import base64
 import inspect
+import traceback
 
+import kwasm.embed
+import matplotlib
+import matplotlib.pyplot as plt
+from gdsfactory.serialization import clean_value_json
+
+matplotlib.use("Agg")
+
+from cspdk.si500 import PDK
 from cspdk.si500 import _cells as cells
 from cspdk.si500.config import PATH
 
+PDK.activate()
+
 filepath = PATH.repo / "docs" / "cells_si500.md"
+kwasm_dir = PATH.repo / "docs" / "kwasm"
+gds_dir = kwasm_dir / "gds"
 
 skip = {}
-
 skip_plot: tuple[str, ...] = ("",)
 skip_settings: tuple[str, ...] = ()
 
+
+def _setup_kwasm_viewer() -> None:
+    gds_dir.mkdir(parents=True, exist_ok=True)
+    viewer_path = kwasm_dir / "viewer.html"
+    if viewer_path.exists():
+        return
+    template = kwasm.embed._read_artifacts()
+    template = template.replace("KWASM_GDS_B64", "")
+    lyp_path = PATH.lyp
+    if lyp_path.exists():
+        lyp_b64 = base64.b64encode(lyp_path.read_bytes()).decode("ascii")
+        template = template.replace("KWASM_LYP_B64", lyp_b64)
+    else:
+        template = template.replace("KWASM_LYP_B64", "")
+    template = template.replace("KWASM_LYRDB_B64", "")
+    template = template.replace("KWASM_NETLIST_B64", "")
+    viewer_path.write_text(template)
+
+
+def _write_gds(name: str) -> bool:
+    try:
+        sig = inspect.signature(cells[name])
+        defaults = {}
+        for p in sig.parameters:
+            v = sig.parameters[p].default
+            if isinstance(v, int | float | str | tuple):
+                defaults[p] = v
+        c = cells[name](**defaults)
+        c.write(str(gds_dir / f"{name}.gds"))
+        c.plot()
+        plt.savefig(str(gds_dir / f"{name}.png"), dpi=150, bbox_inches="tight")
+        plt.close("all")
+    except Exception:
+        traceback.print_exc()
+        plt.close("all")
+        return False
+    else:
+        return True
+
+
+_setup_kwasm_viewer()
 
 with open(filepath, "w+") as f:
     f.write("# Cells Si SOI 500nm\n\n")
@@ -23,40 +77,28 @@ with open(filepath, "w+") as f:
         sig = inspect.signature(cells[name])
         kwargs = ", ".join(
             [
-                f"{p}={repr(sig.parameters[p].default)}"
+                f"{p}={clean_value_json(sig.parameters[p].default)!r}"
                 for p in sig.parameters
                 if isinstance(sig.parameters[p].default, int | float | str | tuple)
                 and p not in skip_settings
             ]
         )
-        if name in skip_plot:
-            f.write(
-                f"""
+        f.write(f"## {name}\n\n")
+        f.write(f"::: cspdk.si500.cells.{name}\n   :noindex:\n\n")
+        if name not in skip_plot:
+            has_gds = _write_gds(name)
+            if has_gds:
+                f.write(f"![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write(
+                    f'<iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
+                    f' loading="lazy" width="100%" height="400"'
+                    f' style="border:none"></iframe>\n\n'
+                )
+            f.write("```python\n")
+            f.write("import cspdk\n\n")
+            f.write(f"c = cspdk.si500.cells.{name}({kwargs}).copy()\n")
+            f.write("c.draw_ports()\n")
+            f.write("c.plot()\n")
+            f.write("```\n\n")
 
-## {name}
-
-
-::: cspdk.si500.cells.{name}
-   :noindex:
-
-"""
-            )
-        else:
-            f.write(
-                f"""
-
-## {name}
-
-
-::: cspdk.si500.cells.{name}
-   :noindex:
-
-```python
-import cspdk
-
-c = cspdk.si500.cells.{name}({kwargs}).copy()
-c.draw_ports()
-c.plot()
-```
-"""
-            )
+print(f"Wrote {filepath}")

--- a/.github/write_cells_sin300.py
+++ b/.github/write_cells_sin300.py
@@ -1,17 +1,71 @@
-"""Write docs."""
+"""Write cell docs as Markdown with kwasm viewers."""
 
+import base64
 import inspect
+import traceback
 
+import kwasm.embed
+import matplotlib
+import matplotlib.pyplot as plt
+from gdsfactory.serialization import clean_value_json
+
+matplotlib.use("Agg")
+
+from cspdk.sin300 import PDK
 from cspdk.sin300 import _cells as cells
 from cspdk.sin300.config import PATH
 
+PDK.activate()
+
 filepath = PATH.repo / "docs" / "cells_sin300.md"
+kwasm_dir = PATH.repo / "docs" / "kwasm"
+gds_dir = kwasm_dir / "gds"
 
 skip = {}
-
 skip_plot: tuple[str, ...] = ("",)
 skip_settings: tuple[str, ...] = ()
 
+
+def _setup_kwasm_viewer() -> None:
+    gds_dir.mkdir(parents=True, exist_ok=True)
+    viewer_path = kwasm_dir / "viewer.html"
+    if viewer_path.exists():
+        return
+    template = kwasm.embed._read_artifacts()
+    template = template.replace("KWASM_GDS_B64", "")
+    lyp_path = PATH.lyp
+    if lyp_path.exists():
+        lyp_b64 = base64.b64encode(lyp_path.read_bytes()).decode("ascii")
+        template = template.replace("KWASM_LYP_B64", lyp_b64)
+    else:
+        template = template.replace("KWASM_LYP_B64", "")
+    template = template.replace("KWASM_LYRDB_B64", "")
+    template = template.replace("KWASM_NETLIST_B64", "")
+    viewer_path.write_text(template)
+
+
+def _write_gds(name: str) -> bool:
+    try:
+        sig = inspect.signature(cells[name])
+        defaults = {}
+        for p in sig.parameters:
+            v = sig.parameters[p].default
+            if isinstance(v, int | float | str | tuple):
+                defaults[p] = v
+        c = cells[name](**defaults)
+        c.write(str(gds_dir / f"{name}.gds"))
+        c.plot()
+        plt.savefig(str(gds_dir / f"{name}.png"), dpi=150, bbox_inches="tight")
+        plt.close("all")
+    except Exception:
+        traceback.print_exc()
+        plt.close("all")
+        return False
+    else:
+        return True
+
+
+_setup_kwasm_viewer()
 
 with open(filepath, "w+") as f:
     f.write("# Cells SiN300\n\n")
@@ -23,40 +77,28 @@ with open(filepath, "w+") as f:
         sig = inspect.signature(cells[name])
         kwargs = ", ".join(
             [
-                f"{p}={repr(sig.parameters[p].default)}"
+                f"{p}={clean_value_json(sig.parameters[p].default)!r}"
                 for p in sig.parameters
                 if isinstance(sig.parameters[p].default, int | float | str | tuple)
                 and p not in skip_settings
             ]
         )
-        if name in skip_plot:
-            f.write(
-                f"""
+        f.write(f"## {name}\n\n")
+        f.write(f"::: cspdk.sin300.cells.{name}\n   :noindex:\n\n")
+        if name not in skip_plot:
+            has_gds = _write_gds(name)
+            if has_gds:
+                f.write(f"![{name}](kwasm/gds/{name}.png)\n\n")
+                f.write(
+                    f'<iframe src="kwasm/viewer.html?url=gds/{name}.gds"'
+                    f' loading="lazy" width="100%" height="400"'
+                    f' style="border:none"></iframe>\n\n'
+                )
+            f.write("```python\n")
+            f.write("import cspdk\n\n")
+            f.write(f"c = cspdk.sin300.cells.{name}({kwargs}).copy()\n")
+            f.write("c.draw_ports()\n")
+            f.write("c.plot()\n")
+            f.write("```\n\n")
 
-## {name}
-
-
-::: cspdk.sin300.cells.{name}
-   :noindex:
-
-"""
-            )
-        else:
-            f.write(
-                f"""
-
-## {name}
-
-
-::: cspdk.sin300.cells.{name}
-   :noindex:
-
-```python
-import cspdk
-
-c = cspdk.sin300.cells.{name}({kwargs}).copy()
-c.draw_ports()
-c.plot()
-```
-"""
-            )
+print(f"Wrote {filepath}")

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ docs-pdf:
 	uv run python .github/write_cells_si500.py
 	uv run python .github/write_cells_sin300.py
 	cp CHANGELOG.md docs/changelog.md
+	cp README.md docs/index.md
 	uv run mkdocs build -f mkdocs-pdf.yml
 
 docs:
@@ -61,6 +62,7 @@ docs:
 	uv run python .github/write_cells_si500.py
 	uv run python .github/write_cells_sin300.py
 	cp CHANGELOG.md docs/changelog.md
+	cp README.md docs/index.md
 	uv run --extra docs zensical build -f docs/zensical.toml
 
 docs-serve:
@@ -69,6 +71,7 @@ docs-serve:
 	uv run python .github/write_cells_si500.py
 	uv run python .github/write_cells_sin300.py
 	cp CHANGELOG.md docs/changelog.md
+	cp README.md docs/index.md
 	uv run --extra docs zensical serve -f docs/zensical.toml -a localhost:8080
 
 update-changelog:


### PR DESCRIPTION
## Summary
- Rewrote all 4 `write_cells_*.py` scripts to generate PNG plots and kwasm interactive GDS viewers for each cell (matching HHI's pattern)
- Fixed `docs/index.md` — the MyST `{include}` directive doesn't render in mkdocs/zensical, so the Makefile now copies `README.md` to `docs/index.md` at build time

## Test plan
- [ ] Verify `make docs` builds successfully and cells appear with images + interactive viewers
- [ ] Confirm the index page renders the README content instead of `{include} ../README.md`
- [ ] Check kwasm interactive viewers load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add automated generation of cell documentation pages with images and kwasm interactive viewers, and fix the docs index build so it uses the project README as the landing page.

New Features:
- Generate static PNG previews and kwasm-based interactive GDS viewers for all documented cells in the si220 cband, si220 oband, si500, and sin300 PDKs.

Enhancements:
- Standardize cell documentation generation scripts to use cleaned JSON-safe default parameter values and include embedded usage examples.

Build:
- Ensure docs builds copy README.md to docs/index.md so the documentation index renders correctly across mkdocs and zensical.