### PR TITLE
Add --verbose flag to twine upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           make build
-          twine upload dist/*
+          twine upload --verbose dist/*
   release_environment:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds --verbose flag to twine upload commands in the release workflow for better upload diagnostics.

Closes #290

## Test plan
- [ ] Trigger a release workflow run and verify twine outputs verbose logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add the --verbose flag to the twine upload step in the GitHub Actions release workflow for more detailed logging.