### PR TITLE
Activate PDK in docs code examples for correct layermap

### DIFF
--- a/.github/write_cells_si220_cband.py
+++ b/.github/write_cells_si220_cband.py
@@ -95,8 +95,9 @@ with open(filepath, "w+") as f:
                     f' style="border:none"></iframe>\n\n'
                 )
             f.write("```python\n")
-            f.write("import cspdk\n\n")
-            f.write(f"c = cspdk.si220.cband.cells.{name}({kwargs}).copy()\n")
+            f.write("from cspdk.si220.cband import cells, PDK\n\n")
+            f.write("PDK.activate()\n\n")
+            f.write(f"c = cells.{name}({kwargs})\n")
             f.write("c.draw_ports()\n")
             f.write("c.plot()\n")
             f.write("```\n\n")

--- a/.github/write_cells_si220_oband.py
+++ b/.github/write_cells_si220_oband.py
@@ -95,8 +95,9 @@ with open(filepath, "w+") as f:
                     f' style="border:none"></iframe>\n\n'
                 )
             f.write("```python\n")
-            f.write("import cspdk\n\n")
-            f.write(f"c = cspdk.si220.oband.cells.{name}({kwargs}).copy()\n")
+            f.write("from cspdk.si220.oband import cells, PDK\n\n")
+            f.write("PDK.activate()\n\n")
+            f.write(f"c = cells.{name}({kwargs})\n")
             f.write("c.draw_ports()\n")
             f.write("c.plot()\n")
             f.write("```\n\n")

--- a/.github/write_cells_si500.py
+++ b/.github/write_cells_si500.py
@@ -95,8 +95,9 @@ with open(filepath, "w+") as f:
                     f' style="border:none"></iframe>\n\n'
                 )
             f.write("```python\n")
-            f.write("import cspdk\n\n")
-            f.write(f"c = cspdk.si500.cells.{name}({kwargs}).copy()\n")
+            f.write("from cspdk.si500 import cells, PDK\n\n")
+            f.write("PDK.activate()\n\n")
+            f.write(f"c = cells.{name}({kwargs})\n")
             f.write("c.draw_ports()\n")
             f.write("c.plot()\n")
             f.write("```\n\n")

--- a/.github/write_cells_sin300.py
+++ b/.github/write_cells_sin300.py
@@ -95,8 +95,9 @@ with open(filepath, "w+") as f:
                     f' style="border:none"></iframe>\n\n'
                 )
             f.write("```python\n")
-            f.write("import cspdk\n\n")
-            f.write(f"c = cspdk.sin300.cells.{name}({kwargs}).copy()\n")
+            f.write("from cspdk.sin300 import cells, PDK\n\n")
+            f.write("PDK.activate()\n\n")
+            f.write(f"c = cells.{name}({kwargs})\n")
             f.write("c.draw_ports()\n")
             f.write("c.plot()\n")
             f.write("```\n\n")

--- a/cspdk/si220/cband/__init__.py
+++ b/cspdk/si220/cband/__init__.py
@@ -41,6 +41,12 @@ def get_pdk() -> Pdk:
     )
 
 
+def activate_pdk() -> None:
+    """Activate Cornerstone Si220 Cband PDK."""
+    pdk = get_pdk()
+    pdk.activate()
+
+
 PDK = get_pdk()
 
 __all__ = [


### PR DESCRIPTION
## Summary

- Add `PDK.activate()` to the code examples generated by all four `write_cells_*.py` scripts, matching the pattern used by amf, ctpdk, and ubc PDKs
- Add missing `activate_pdk()` helper to `cspdk.si220.cband` for consistency with all other sub-PDKs (oband, si340, si500, sin200, sin300, ge_on_si, si_sus)

Without activation, users copying the doc examples get the generic gdsfactory layermap instead of the Cornerstone-specific one.

Fixes #292

## Summary by Sourcery

Ensure Cornerstone Si220 PDK variants are properly activated in generated documentation code examples to use the correct layermap.

New Features:
- Add an activate_pdk() helper for the cspdk.si220.cband PDK to simplify activation in user code.

Enhancements:
- Update all Cornerstone documentation cell-generation scripts to import the appropriate PDK and call PDK.activate() before constructing cells in code examples.