### PR TITLE
Switch CI workflows to pdk-ci-workflow-public

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   review:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/claude-pr-review.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   drc:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/drc.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/drc.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -20,4 +20,4 @@ on:
 
 jobs:
   label:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/issue.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/issue.yml@main

--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   model-coverage:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_coverage.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/model_coverage.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   model-regression:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_regression.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/model_regression.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docs:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/pages.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
       SIMCLOUD_APIKEY: ${{ secrets.SIMCLOUD_APIKEY }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   draft:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/release-drafter.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/sample-projects.yml
+++ b/.github/workflows/sample-projects.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   test-sample-projects:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/test-sample-projects.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/test-sample-projects.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   test:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/test_code.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   coverage:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_coverage.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/test_coverage.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   badges:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/update_badges.yml@main
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/update_badges.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ install:
 	uv sync --extra docs --extra dev
 
 dev: install
-	curl -sf https://raw.githubusercontent.com/doplaydo/pdk-ci-workflow/main/templates/.pre-commit-config.yaml -o .pre-commit-config.yaml
+	curl -sf https://raw.githubusercontent.com/doplaydo/pdk-ci-workflow-public/main/templates/.pre-commit-config.yaml -o .pre-commit-config.yaml
 	uv run pre-commit install
 
 rm-samples:


### PR DESCRIPTION
## Summary
- Switches all reusable workflow references from `doplaydo/pdk-ci-workflow` to `doplaydo/pdk-ci-workflow-public`
- Updates `.pre-commit-config.yaml` to use the public repo for hooks

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update all GitHub Actions workflows to reference doplaydo/pdk-ci-workflow-public instead of the private doplaydo/pdk-ci-workflow repository.