### PR TITLE
fix(schematic): bend ports left→top to match GDS

### DIFF
--- a/cspdk/_schematic.py
+++ b/cspdk/_schematic.py
@@ -35,10 +35,10 @@ _LEFT_RIGHT = [
     {"name": "o2", "side": "right", "type": "photonic"},
 ]
 
-# 2-port 90-degree bend
-_LEFT_BOTTOM = [
+# 2-port 90-degree bend (o1 left/180°, o2 top/90°) — matches bend_euler GDS
+_LEFT_TOP = [
     {"name": "o1", "side": "left", "type": "photonic"},
-    {"name": "o2", "side": "bottom", "type": "photonic"},
+    {"name": "o2", "side": "top", "type": "photonic"},
 ]
 
 # 1x2 splitter (mmi1x2)

--- a/cspdk/ge_on_si/_schematic.py
+++ b/cspdk/ge_on_si/_schematic.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from cspdk._schematic import (
-    _LEFT_BOTTOM,
     _LEFT_RIGHT,
+    _LEFT_TOP,
     _PAD,
     schematic,
 )
 
 straight_schematic = schematic("straight", ["waveguide"], _LEFT_RIGHT)
-bend_euler_schematic = schematic("bend", ["bend", "euler"], _LEFT_BOTTOM)
+bend_euler_schematic = schematic("bend", ["bend", "euler"], _LEFT_TOP)
 bend_s_schematic = schematic("sbend", ["bend", "s"], _LEFT_RIGHT)
 taper_schematic = schematic("taper", ["taper"], _LEFT_RIGHT)
 pad_schematic = schematic("pad", ["pad"], _PAD)

--- a/cspdk/si220/cband/_schematic.py
+++ b/cspdk/si220/cband/_schematic.py
@@ -8,8 +8,8 @@ from cspdk._schematic import (
     _CROSSING,
     _GRATING,
     _HEATER_TOP,
-    _LEFT_BOTTOM,
     _LEFT_RIGHT,
+    _LEFT_TOP,
     _PAD,
     _WIRE_BEND,
     _WIRE_STRAIGHT,
@@ -46,7 +46,7 @@ straight_rib_schematic = schematic(
 bend_euler_schematic = schematic(
     "bend",
     ["bend", "euler"],
-    _LEFT_BOTTOM,
+    _LEFT_TOP,
     models=[sax_model("bend_euler", _MODULE, ["o1", "o2"])],
 )
 bend_s_schematic = schematic(

--- a/cspdk/si220/oband/_schematic.py
+++ b/cspdk/si220/oband/_schematic.py
@@ -8,8 +8,8 @@ from cspdk._schematic import (
     _CROSSING,
     _GRATING,
     _HEATER_FULL,
-    _LEFT_BOTTOM,
     _LEFT_RIGHT,
+    _LEFT_TOP,
     _PAD,
     _WIRE_BEND,
     _WIRE_STRAIGHT,
@@ -46,7 +46,7 @@ straight_rib_schematic = schematic(
 bend_euler_schematic = schematic(
     "bend",
     ["bend", "euler"],
-    _LEFT_BOTTOM,
+    _LEFT_TOP,
     models=[sax_model("bend_euler", _MODULE, ["o1", "o2"])],
 )
 bend_s_schematic = schematic(

--- a/cspdk/si340/_schematic.py
+++ b/cspdk/si340/_schematic.py
@@ -10,8 +10,8 @@ from cspdk._schematic import (
     _1X2,
     _2X2,
     _GRATING,
-    _LEFT_BOTTOM,
     _LEFT_RIGHT,
+    _LEFT_TOP,
     _MZI_1X2,
     _PAD,
     _WIRE_BEND,
@@ -19,7 +19,7 @@ from cspdk._schematic import (
 )
 
 straight_schematic = schematic("straight", ["waveguide"], _LEFT_RIGHT)
-bend_euler_schematic = schematic("bend", ["bend", "euler"], _LEFT_BOTTOM)
+bend_euler_schematic = schematic("bend", ["bend", "euler"], _LEFT_TOP)
 bend_s_schematic = schematic("sbend", ["bend", "s"], _LEFT_RIGHT)
 wire_corner_schematic = schematic("wire-corner", ["wire", "corner"], _WIRE_BEND)
 taper_schematic = schematic("taper", ["taper"], _LEFT_RIGHT)

--- a/cspdk/si500/_schematic.py
+++ b/cspdk/si500/_schematic.py
@@ -10,8 +10,8 @@ from cspdk._schematic import (
     _1X2,
     _2X2,
     _GRATING,
-    _LEFT_BOTTOM,
     _LEFT_RIGHT,
+    _LEFT_TOP,
     _MZI_1X2,
     _PAD,
     _WIRE_BEND,
@@ -19,7 +19,7 @@ from cspdk._schematic import (
 )
 
 straight_schematic = schematic("straight", ["waveguide"], _LEFT_RIGHT)
-bend_euler_schematic = schematic("bend", ["bend", "euler"], _LEFT_BOTTOM)
+bend_euler_schematic = schematic("bend", ["bend", "euler"], _LEFT_TOP)
 bend_s_schematic = schematic("sbend", ["bend", "s"], _LEFT_RIGHT)
 wire_corner_schematic = schematic("wire-corner", ["wire", "corner"], _WIRE_BEND)
 taper_schematic = schematic("taper", ["taper"], _LEFT_RIGHT)

--- a/cspdk/si_sus/_schematic.py
+++ b/cspdk/si_sus/_schematic.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 from cspdk._schematic import (
     _GRATING,
-    _LEFT_BOTTOM,
     _LEFT_RIGHT,
+    _LEFT_TOP,
     _PAD,
     schematic,
 )
 
 straight_schematic = schematic("straight", ["waveguide"], _LEFT_RIGHT)
-bend_euler_schematic = schematic("bend", ["bend", "euler"], _LEFT_BOTTOM)
-bend_circular_schematic = schematic("bend", ["bend", "circular"], _LEFT_BOTTOM)
+bend_euler_schematic = schematic("bend", ["bend", "euler"], _LEFT_TOP)
+bend_circular_schematic = schematic("bend", ["bend", "circular"], _LEFT_TOP)
 bend_s_schematic = schematic("sbend", ["bend", "s"], _LEFT_RIGHT)
 taper_schematic = schematic("taper", ["taper"], _LEFT_RIGHT)
 grating_coupler_rectangular_schematic = schematic(

--- a/cspdk/sin200/_schematic.py
+++ b/cspdk/sin200/_schematic.py
@@ -6,8 +6,8 @@ from cspdk._schematic import (
     _1X2,
     _2X2,
     _GRATING,
-    _LEFT_BOTTOM,
     _LEFT_RIGHT,
+    _LEFT_TOP,
     _MZI_1X2,
     _PAD,
     _WIRE_BEND,
@@ -15,7 +15,7 @@ from cspdk._schematic import (
 )
 
 straight_schematic = schematic("straight", ["waveguide"], _LEFT_RIGHT)
-bend_euler_schematic = schematic("bend", ["bend", "euler"], _LEFT_BOTTOM)
+bend_euler_schematic = schematic("bend", ["bend", "euler"], _LEFT_TOP)
 bend_s_schematic = schematic("sbend", ["bend", "s"], _LEFT_RIGHT)
 wire_corner_schematic = schematic("wire-corner", ["wire", "corner"], _WIRE_BEND)
 taper_schematic = schematic("taper", ["taper"], _LEFT_RIGHT)

--- a/cspdk/sin300/_schematic.py
+++ b/cspdk/sin300/_schematic.py
@@ -6,8 +6,8 @@ from cspdk._schematic import (
     _1X2,
     _2X2,
     _GRATING,
-    _LEFT_BOTTOM,
     _LEFT_RIGHT,
+    _LEFT_TOP,
     _MZI_1X2,
     _PAD,
     _WIRE_BEND,
@@ -27,7 +27,7 @@ straight_schematic = schematic(
 bend_euler_schematic = schematic(
     "bend",
     ["bend", "euler"],
-    _LEFT_BOTTOM,
+    _LEFT_TOP,
     models=[sax_model("bend_euler", _MODULE, ["o1", "o2"])],
 )
 bend_s_schematic = schematic(

--- a/tests/_schematic_checks.py
+++ b/tests/_schematic_checks.py
@@ -84,6 +84,29 @@ def check_ports_subset_of_component(pdk) -> None:
         )
 
 
+def check_bend_ports_left_top(pdk) -> None:
+    """90-degree bend schematics declare o1 on the left and o2 on the top.
+
+    This matches the physical bend_euler/bend_circular GDS (o1 at 180°, o2 at
+    90°) and the canonical Mosaic ``bend`` symbol. Guards against regressing to
+    the old left/bottom layout.
+    """
+    checked = False
+    for name, factory in schematic_driven_cells(pdk):
+        if "bend_euler" not in name and "bend_circular" not in name:
+            continue
+        s = factory.get_schematic()
+        sides = {p["name"]: p["side"] for p in s.info["ports"]}
+        assert sides.get("o1") == "left", (
+            f"{name}: o1 side {sides.get('o1')!r} != 'left'"
+        )
+        assert sides.get("o2") == "top", (
+            f"{name}: o2 side {sides.get('o2')!r} != 'top'"
+        )
+        checked = True
+    assert checked, "no bend_euler/bend_circular schematic-driven cells found"
+
+
 def check_sax_model_refs(pdk, *, has_models: bool) -> None:
     for name, factory in schematic_driven_cells(pdk):
         s = factory.get_schematic()

--- a/tests/_schematic_checks.py
+++ b/tests/_schematic_checks.py
@@ -93,7 +93,7 @@ def check_bend_ports_left_top(pdk) -> None:
     """
     checked = False
     for name, factory in schematic_driven_cells(pdk):
-        if "bend_euler" not in name and "bend_circular" not in name:
+        if name not in ("bend_euler", "bend_circular"):
             continue
         s = factory.get_schematic()
         sides = {p["name"]: p["side"] for p in s.info["ports"]}

--- a/tests/test_schematics_ge_on_si.py
+++ b/tests/test_schematics_ge_on_si.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_symbol_present,
@@ -20,6 +21,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_bend_ports_left_top() -> None:
+    """90-degree bend schematics declare o1 left, o2 top (matches GDS)."""
+    check_bend_ports_left_top(PDK)
 
 
 def test_ports_subset_of_component() -> None:

--- a/tests/test_schematics_si220_cband.py
+++ b/tests/test_schematics_si220_cband.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_sax_port_order_matches_sdict,
@@ -21,6 +22,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_bend_ports_left_top() -> None:
+    """90-degree bend schematics declare o1 left, o2 top (matches GDS)."""
+    check_bend_ports_left_top(PDK)
 
 
 def test_ports_subset_of_component() -> None:

--- a/tests/test_schematics_si220_oband.py
+++ b/tests/test_schematics_si220_oband.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_sax_port_order_matches_sdict,
@@ -21,6 +22,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_bend_ports_left_top() -> None:
+    """90-degree bend schematics declare o1 left, o2 top (matches GDS)."""
+    check_bend_ports_left_top(PDK)
 
 
 def test_ports_subset_of_component() -> None:

--- a/tests/test_schematics_si340.py
+++ b/tests/test_schematics_si340.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_symbol_present,
@@ -20,6 +21,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_bend_ports_left_top() -> None:
+    """90-degree bend schematics declare o1 left, o2 top (matches GDS)."""
+    check_bend_ports_left_top(PDK)
 
 
 def test_ports_subset_of_component() -> None:

--- a/tests/test_schematics_si500.py
+++ b/tests/test_schematics_si500.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_symbol_present,
@@ -20,6 +21,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_bend_ports_left_top() -> None:
+    """90-degree bend schematics declare o1 left, o2 top (matches GDS)."""
+    check_bend_ports_left_top(PDK)
 
 
 def test_ports_subset_of_component() -> None:

--- a/tests/test_schematics_si_sus.py
+++ b/tests/test_schematics_si_sus.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_symbol_present,
@@ -20,6 +21,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_bend_ports_left_top() -> None:
+    """90-degree bend schematics declare o1 left, o2 top (matches GDS)."""
+    check_bend_ports_left_top(PDK)
 
 
 def test_ports_subset_of_component() -> None:

--- a/tests/test_schematics_sin200.py
+++ b/tests/test_schematics_sin200.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_symbol_present,
@@ -20,6 +21,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_bend_ports_left_top() -> None:
+    """90-degree bend schematics declare o1 left, o2 top (matches GDS)."""
+    check_bend_ports_left_top(PDK)
 
 
 def test_ports_subset_of_component() -> None:

--- a/tests/test_schematics_sin300.py
+++ b/tests/test_schematics_sin300.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_sax_port_order_matches_sdict,
@@ -21,6 +22,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_bend_ports_left_top() -> None:
+    """90-degree bend schematics declare o1 left, o2 top (matches GDS)."""
+    check_bend_ports_left_top(PDK)
 
 
 def test_ports_subset_of_component() -> None:


### PR DESCRIPTION
## Problem
The bend_euler and bend_circular schematics declared o2 on the bottom (using _LEFT_BOTTOM preset, 270°), but the physical GDS has o2 on top (90°). The schematic was consistently wrong vs the GDS.

## Changes
- Replaced the _LEFT_BOTTOM bend port-side preset with _LEFT_TOP (o1 left/180°, o2 top/90°) in cspdk/_schematic.py
- Switched bend_euler and bend_circular (in si_sus) to the new preset across all 8 sub-PDKs: si220 cband/oband, sin300, sin200, si340, si500, ge_on_si, si_sus
- Added check_bend_ports_left_top helper and wired test_bend_ports_left_top into each per-PDK schematic test

## Testing
All 35 schematic tests pass.

## Note
Companion change in gdsfactoryplus/Mosaic flips the built-in bend glyph to left→top (separate PR). Both should land together — the Mosaic bend glyph is global, which is why all sub-PDKs are updated in one pass.

## Summary by Sourcery

Align 90-degree bend schematics with their physical GDS orientation across all sub-PDKs and guard this behavior with tests.

Bug Fixes:
- Correct 90-degree bend schematics so o1 is on the left and o2 is on the top to match the underlying bend_euler and bend_circular GDS orientation.

Tests:
- Add a shared check that verifies bend_euler and bend_circular schematics expose o1 on the left and o2 on the top, and wire it into each sub-PDK schematic test suite.