### PR TITLE
fix(schematic): align schematic port sides with GDS across all symbols

### DIFF
--- a/cspdk/_schematic.py
+++ b/cspdk/_schematic.py
@@ -56,15 +56,17 @@ _2X2 = [
     {"name": "o4", "side": "right", "type": "photonic"},
 ]
 
-# ring_double: two parallel through-buses (o1-o2 and o3-o4), each left->right.
-# Matches the GDS (o1/o3 at 180°/left, o2/o4 at 0°/right) and the Mosaic
-# ring-double symbol, which draws two horizontal buses. Using _2X2 here would
-# group o1,o2 on the left and o3,o4 on the right, twisting the buses.
+# ring_double: two parallel through-buses with the GDS port naming
+# o1=bottom-left, o2=bottom-right, o3=top-left, o4=top-right. Ports are listed
+# clockwise-from-left within each side (left bottom->top: o1, o3; right
+# top->bottom: o4, o2) so the nyanlib->Mosaic bridge places them to match the
+# layout. (gdsfactory names these by bus-pair, not clockwise, so the list order
+# here is deliberately o1, o3, o4, o2.)
 _RING_DOUBLE = [
     {"name": "o1", "side": "left", "type": "photonic"},
-    {"name": "o2", "side": "right", "type": "photonic"},
     {"name": "o3", "side": "left", "type": "photonic"},
     {"name": "o4", "side": "right", "type": "photonic"},
+    {"name": "o2", "side": "right", "type": "photonic"},
 ]
 
 # ring coupler element: bus (o1 left, o4 right) with two ports up to the ring

--- a/cspdk/_schematic.py
+++ b/cspdk/_schematic.py
@@ -48,11 +48,32 @@ _1X2 = [
     {"name": "o3", "side": "right", "type": "photonic"},
 ]
 
-# 2x2 coupler / mmi2x2 / ring_double / mzi (with 2x2 splitter)
+# 2x2 coupler / mmi2x2 / mzi (with 2x2 splitter)
 _2X2 = [
     {"name": "o1", "side": "left", "type": "photonic"},
     {"name": "o2", "side": "left", "type": "photonic"},
     {"name": "o3", "side": "right", "type": "photonic"},
+    {"name": "o4", "side": "right", "type": "photonic"},
+]
+
+# ring_double: two parallel through-buses (o1-o2 and o3-o4), each left->right.
+# Matches the GDS (o1/o3 at 180°/left, o2/o4 at 0°/right) and the Mosaic
+# ring-double symbol, which draws two horizontal buses. Using _2X2 here would
+# group o1,o2 on the left and o3,o4 on the right, twisting the buses.
+_RING_DOUBLE = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "right", "type": "photonic"},
+    {"name": "o3", "side": "left", "type": "photonic"},
+    {"name": "o4", "side": "right", "type": "photonic"},
+]
+
+# ring coupler element: bus (o1 left, o4 right) with two ports up to the ring
+# (o2, o3 on top). Matches the GDS (o2/o3 at 90°). No dedicated Mosaic symbol;
+# renders as a generic box.
+_RING_COUPLER = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "top", "type": "photonic"},
+    {"name": "o3", "side": "top", "type": "photonic"},
     {"name": "o4", "side": "right", "type": "photonic"},
 ]
 
@@ -63,18 +84,20 @@ _MZI_1X2 = [
     {"name": "o3", "side": "right", "type": "photonic"},
 ]
 
-# 4-port crossing
+# 4-port crossing (o1 left/180°, o2 top/90°, o3 right/0°, o4 bottom/270°) —
+# matches the GDS port orientations and the symmetric Mosaic crossing symbol.
 _CROSSING = [
     {"name": "o1", "side": "left", "type": "photonic"},
-    {"name": "o2", "side": "bottom", "type": "photonic"},
+    {"name": "o2", "side": "top", "type": "photonic"},
     {"name": "o3", "side": "right", "type": "photonic"},
-    {"name": "o4", "side": "top", "type": "photonic"},
+    {"name": "o4", "side": "bottom", "type": "photonic"},
 ]
 
-# Grating coupler (bus left, fiber above)
+# Grating coupler: bus o1 left/180°, fiber port o2 right/0° — matches the GDS
+# (o2 at 0°) and the Mosaic grating-coupler symbol, whose fan radiates right.
 _GRATING = [
     {"name": "o1", "side": "left", "type": "photonic"},
-    {"name": "o2", "side": "top", "type": "photonic"},
+    {"name": "o2", "side": "right", "type": "photonic"},
 ]
 
 # Pad with 4 electrical edges
@@ -85,10 +108,11 @@ _PAD = [
     {"name": "e4", "side": "bottom", "type": "electric"},
 ]
 
-# Wire bend (electrical)
+# Wire bend / corner (electrical 90° turn): e1 left/180°, e2 top/90° — matches
+# the GDS (wire_corner/bend_metal e2 at 90°), mirroring the photonic bend.
 _WIRE_BEND = [
     {"name": "e1", "side": "left", "type": "electric"},
-    {"name": "e2", "side": "bottom", "type": "electric"},
+    {"name": "e2", "side": "top", "type": "electric"},
 ]
 
 # Wire straight (electrical)
@@ -111,9 +135,9 @@ _HEATER_FULL = [
     {"name": "o2", "side": "right", "type": "photonic"},
     {"name": "l_e1", "side": "left", "type": "electric"},
     {"name": "l_e2", "side": "top", "type": "electric"},
-    {"name": "l_e3", "side": "left", "type": "electric"},
+    {"name": "l_e3", "side": "right", "type": "electric"},
     {"name": "l_e4", "side": "bottom", "type": "electric"},
-    {"name": "r_e1", "side": "right", "type": "electric"},
+    {"name": "r_e1", "side": "left", "type": "electric"},
     {"name": "r_e2", "side": "top", "type": "electric"},
     {"name": "r_e3", "side": "right", "type": "electric"},
     {"name": "r_e4", "side": "bottom", "type": "electric"},

--- a/cspdk/si220/cband/_schematic.py
+++ b/cspdk/si220/cband/_schematic.py
@@ -11,6 +11,8 @@ from cspdk._schematic import (
     _LEFT_RIGHT,
     _LEFT_TOP,
     _PAD,
+    _RING_COUPLER,
+    _RING_DOUBLE,
     _WIRE_BEND,
     _WIRE_STRAIGHT,
     sax_model,
@@ -60,7 +62,7 @@ bend_s_schematic = schematic(
 wire_corner_schematic = schematic("wire-corner", ["wire", "corner"], _WIRE_BEND)
 wire_corner45_schematic = schematic("wire-corner", ["wire", "corner"], _WIRE_BEND)
 wire_corner45_straight_schematic = schematic(
-    "wire-corner", ["wire", "corner"], _WIRE_STRAIGHT
+    "wire-corner", ["wire", "corner"], _WIRE_BEND
 )
 straight_metal_schematic = schematic("wire", ["wire", "straight"], _WIRE_STRAIGHT)
 bend_metal_schematic = schematic("wire-bend", ["wire", "bend"], _WIRE_BEND)
@@ -105,13 +107,13 @@ coupler_schematic = schematic(
 coupler_ring_schematic = schematic(
     "coupler-ring",
     ["coupler", "ring"],
-    _2X2,
+    _RING_COUPLER,
     models=[sax_model("coupler_ring", _MODULE, ["o1", "o2", "o3", "o4"])],
 )
 
 # Rings (no top-level SAX model; composites)
 ring_single_schematic = schematic("ring-single", ["ring", "single"], _LEFT_RIGHT)
-ring_double_schematic = schematic("ring-double", ["ring", "double"], _2X2)
+ring_double_schematic = schematic("ring-double", ["ring", "double"], _RING_DOUBLE)
 
 # MZI (composite; cband mzi uses 2x2 splitter so 4 ports)
 mzi_schematic = schematic("mzi", ["mzi"], _2X2)
@@ -121,7 +123,10 @@ spiral_schematic = schematic("spiral", ["spiral"], _LEFT_RIGHT)
 
 # Heaters
 straight_heater_metal_schematic = schematic(
-    "modulator",
+    # Rendered as a generic model-driven box ("ckt") so all heater ports show.
+    # The Mosaic "modulator" symbol uses hardcoded conn and cannot represent a
+    # multi-port heater; see the model-driven-modulator follow-up issue.
+    "ckt",
     ["heater", "modulator"],
     _HEATER_TOP,
     models=[
@@ -145,7 +150,7 @@ straight_heater_metal_schematic = schematic(
     ],
 )
 straight_heater_meander_schematic = schematic(
-    "modulator", ["heater", "modulator", "meander"], _HEATER_TOP
+    "ckt", ["heater", "modulator", "meander"], _HEATER_TOP
 )
 
 # Grating couplers

--- a/cspdk/si220/oband/_schematic.py
+++ b/cspdk/si220/oband/_schematic.py
@@ -11,6 +11,8 @@ from cspdk._schematic import (
     _LEFT_RIGHT,
     _LEFT_TOP,
     _PAD,
+    _RING_COUPLER,
+    _RING_DOUBLE,
     _WIRE_BEND,
     _WIRE_STRAIGHT,
     sax_model,
@@ -60,7 +62,7 @@ bend_s_schematic = schematic(
 wire_corner_schematic = schematic("wire-corner", ["wire", "corner"], _WIRE_BEND)
 wire_corner45_schematic = schematic("wire-corner", ["wire", "corner"], _WIRE_BEND)
 wire_corner45_straight_schematic = schematic(
-    "wire-corner", ["wire", "corner"], _WIRE_STRAIGHT
+    "wire-corner", ["wire", "corner"], _WIRE_BEND
 )
 straight_metal_schematic = schematic("wire", ["wire", "straight"], _WIRE_STRAIGHT)
 bend_metal_schematic = schematic("wire-bend", ["wire", "bend"], _WIRE_BEND)
@@ -105,19 +107,22 @@ coupler_schematic = schematic(
 coupler_ring_schematic = schematic(
     "coupler-ring",
     ["coupler", "ring"],
-    _2X2,
+    _RING_COUPLER,
     models=[sax_model("coupler_ring", _MODULE, ["o1", "o2", "o3", "o4"])],
 )
 
 # Rings / MZI / spirals — composite, no top-level SAX model
 ring_single_schematic = schematic("ring-single", ["ring", "single"], _LEFT_RIGHT)
-ring_double_schematic = schematic("ring-double", ["ring", "double"], _2X2)
+ring_double_schematic = schematic("ring-double", ["ring", "double"], _RING_DOUBLE)
 mzi_schematic = schematic("mzi", ["mzi"], _2X2)
 spiral_schematic = schematic("spiral", ["spiral"], _LEFT_RIGHT)
 
 # Heaters — oband exposes all via-stack electrical ports
 straight_heater_metal_schematic = schematic(
-    "modulator",
+    # Rendered as a generic model-driven box ("ckt") so all heater ports show.
+    # The Mosaic "modulator" symbol uses hardcoded conn and cannot represent a
+    # multi-port heater; see the model-driven-modulator follow-up issue.
+    "ckt",
     ["heater", "modulator"],
     _HEATER_FULL,
     models=[
@@ -142,7 +147,7 @@ straight_heater_metal_schematic = schematic(
 )
 # straight_heater_meander inherits the same full-port layout; no SAX model.
 straight_heater_meander_schematic = schematic(
-    "modulator", ["heater", "modulator", "meander"], _HEATER_FULL
+    "ckt", ["heater", "modulator", "meander"], _HEATER_FULL
 )
 
 # Grating couplers

--- a/tests/_schematic_checks.py
+++ b/tests/_schematic_checks.py
@@ -141,14 +141,23 @@ def check_all_ports_match_gds(pdk) -> None:
         except Exception:
             # Composite cells can fail to build in a shared pytest session due
             # to cross-band kfactory cache contamination (see _COMPOSITE_SKIP);
-            # their geometry is locked by the per-band reference-GDS tests.
-            continue
+            # their geometry is locked by the per-band reference-GDS tests. Only
+            # tolerate this for known composites — a build failure anywhere else
+            # is a real error and must fail the test.
+            if name in _COMPOSITE_SKIP:
+                continue
+            raise
         for p in s.info["ports"]:
             if (name, p["name"]) in _GDS_ORIENT_EXEMPT:
                 continue
             want = _SIDE_ORIENTATION.get(p["side"])
             ap = ports.get(p["name"])
-            if ap is None or ap.orientation is None or want is None:
+            if ap is None:
+                mismatches.append(
+                    f"{name}.{p['name']}: declared in schematic but missing on the GDS component"
+                )
+                continue
+            if ap.orientation is None or want is None:
                 continue
             got = float(ap.orientation) % 360
             if not _orientation_close(got, want):

--- a/tests/_schematic_checks.py
+++ b/tests/_schematic_checks.py
@@ -170,6 +170,66 @@ def check_all_ports_match_gds(pdk) -> None:
     )
 
 
+# Cells exempt from the clockwise-order check. The heaters render as a generic
+# "ckt" box but are physically wide devices whose via-stack ports face inward
+# (e.g. a left-facing port sits at the far-right x). Collapsed onto a unit box,
+# "clockwise from the layout" is not meaningful, so their multi-port sides are
+# not order-checked. (Tracked for a proper symbol in doplaydo/gdsfactoryplus#3050.)
+_CLOCKWISE_EXEMPT = {"straight_heater_metal", "straight_heater_meander"}
+
+
+def check_ports_clockwise_from_left(pdk) -> None:
+    """Schematic ports are listed clockwise-from-left within each side.
+
+    The nyanlib->Mosaic bridge converts gdsfactory's clockwise port ordering into
+    Mosaic's top->bottom rendering by reversing the left and bottom side groups.
+    For that to land each port where the GDS layout puts it, every schematic must
+    list same-side ports in clockwise order, measured against the real component
+    port positions: left bottom->top, right top->bottom, top left->right, bottom
+    right->left. (Coordinate monotonic per side; equal positions are allowed.)
+    """
+    mismatches = []
+    for name, factory in schematic_driven_cells(pdk):
+        if name in _CLOCKWISE_EXEMPT:
+            continue
+        s = factory.get_schematic()
+        try:
+            ports = {p.name: p for p in pdk.cells[name]().ports}
+        except Exception:
+            if name in _COMPOSITE_SKIP:
+                continue
+            raise
+        by_side: dict[str, list[str]] = {}
+        for p in s.info["ports"]:
+            by_side.setdefault(p["side"], []).append(p["name"])
+        for side, names in by_side.items():
+            # coordinate along the side: y for left/right, x for top/bottom
+            coords = []
+            for nm in names:
+                ap = ports.get(nm)
+                if ap is None:
+                    coords = None
+                    break
+                coords.append(ap.y if side in ("left", "right") else ap.x)
+            if not coords or len(coords) < 2:
+                continue
+            # left/top run ascending (bottom->top, left->right); right/bottom
+            # run descending (top->bottom, right->left). Ties (equal) are fine.
+            ascending = side in ("left", "top")
+            ok = all(
+                (a <= b + 1e-6) if ascending else (a >= b - 1e-6)
+                for a, b in zip(coords, coords[1:])
+            )
+            if not ok:
+                mismatches.append(
+                    f"{name} side {side!r}: schematic order {names} is not "
+                    f"clockwise (GDS coords {[round(c, 2) for c in coords]})"
+                )
+    assert not mismatches, (
+        "schematic ports not listed clockwise-from-left:\n  " + "\n  ".join(mismatches)
+    )
+
+
 def check_sax_model_refs(pdk, *, has_models: bool) -> None:
     for name, factory in schematic_driven_cells(pdk):
         s = factory.get_schematic()

--- a/tests/_schematic_checks.py
+++ b/tests/_schematic_checks.py
@@ -100,11 +100,65 @@ def check_bend_ports_left_top(pdk) -> None:
         assert sides.get("o1") == "left", (
             f"{name}: o1 side {sides.get('o1')!r} != 'left'"
         )
-        assert sides.get("o2") == "top", (
-            f"{name}: o2 side {sides.get('o2')!r} != 'top'"
-        )
+        assert sides.get("o2") == "top", f"{name}: o2 side {sides.get('o2')!r} != 'top'"
         checked = True
     assert checked, "no bend_euler/bend_circular schematic-driven cells found"
+
+
+# side -> canonical outward-normal orientation (mirrors _schematic._SIDE_XY)
+_SIDE_ORIENTATION = {"left": 180, "right": 0, "top": 90, "bottom": 270}
+
+# (cell, port) pairs whose declared schematic side intentionally differs from
+# the GDS port orientation. These are documented exemptions, not bugs:
+_GDS_ORIENT_EXEMPT = {
+    # spiral exposes both optical ports at 0° (same side) in the GDS, but it has
+    # a bespoke Mosaic glyph drawn left->right; matching the GDS here would need
+    # a glyph redraw, not a preset tweak. It is a 2-port inline element, so the
+    # deviation creates no routing "knot".
+    ("spiral", "o1"),
+}
+
+
+def _orientation_close(a: float, b: float) -> bool:
+    return abs(((a - b + 180) % 360) - 180) < 1.0
+
+
+def check_all_ports_match_gds(pdk) -> None:
+    """Every declared schematic port side matches the real GDS port orientation.
+
+    Generalises ``check_bend_ports_left_top`` to the whole schematic-driven set:
+    a port declared on side ``S`` must point in ``S``'s outward direction on the
+    physical component (left=180°, right=0°, top=90°, bottom=270°). This guards
+    against the class of bug where a schematic symbol is "twisted" relative to
+    the GDS layout (the bend left->bottom regression). Known, intentional
+    deviations are listed in ``_GDS_ORIENT_EXEMPT``.
+    """
+    mismatches = []
+    for name, factory in schematic_driven_cells(pdk):
+        s = factory.get_schematic()
+        try:
+            ports = {p.name: p for p in pdk.cells[name]().ports}
+        except Exception:
+            # Composite cells can fail to build in a shared pytest session due
+            # to cross-band kfactory cache contamination (see _COMPOSITE_SKIP);
+            # their geometry is locked by the per-band reference-GDS tests.
+            continue
+        for p in s.info["ports"]:
+            if (name, p["name"]) in _GDS_ORIENT_EXEMPT:
+                continue
+            want = _SIDE_ORIENTATION.get(p["side"])
+            ap = ports.get(p["name"])
+            if ap is None or ap.orientation is None or want is None:
+                continue
+            got = float(ap.orientation) % 360
+            if not _orientation_close(got, want):
+                mismatches.append(
+                    f"{name}.{p['name']}: declared {p['side']!r} ({want}°) "
+                    f"but GDS orientation is {got:.1f}°"
+                )
+    assert not mismatches, (
+        "schematic port sides disagree with GDS layout:\n  " + "\n  ".join(mismatches)
+    )
 
 
 def check_sax_model_refs(pdk, *, has_models: bool) -> None:

--- a/tests/test_schematics_ge_on_si.py
+++ b/tests/test_schematics_ge_on_si.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_all_ports_match_gds,
     check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
@@ -21,6 +22,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_all_ports_match_gds() -> None:
+    """Every declared schematic port side matches the GDS port orientation."""
+    check_all_ports_match_gds(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_ge_on_si.py
+++ b/tests/test_schematics_ge_on_si.py
@@ -6,6 +6,7 @@ import pytest
 from _schematic_checks import (
     check_all_ports_match_gds,
     check_bend_ports_left_top,
+    check_ports_clockwise_from_left,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_symbol_present,
@@ -27,6 +28,11 @@ def test_symbol_present() -> None:
 def test_all_ports_match_gds() -> None:
     """Every declared schematic port side matches the GDS port orientation."""
     check_all_ports_match_gds(PDK)
+
+
+def test_ports_clockwise_from_left() -> None:
+    """Schematic ports are listed clockwise-from-left within each side."""
+    check_ports_clockwise_from_left(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_si220_cband.py
+++ b/tests/test_schematics_si220_cband.py
@@ -6,6 +6,7 @@ import pytest
 from _schematic_checks import (
     check_all_ports_match_gds,
     check_bend_ports_left_top,
+    check_ports_clockwise_from_left,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_sax_port_order_matches_sdict,
@@ -28,6 +29,11 @@ def test_symbol_present() -> None:
 def test_all_ports_match_gds() -> None:
     """Every declared schematic port side matches the GDS port orientation."""
     check_all_ports_match_gds(PDK)
+
+
+def test_ports_clockwise_from_left() -> None:
+    """Schematic ports are listed clockwise-from-left within each side."""
+    check_ports_clockwise_from_left(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_si220_cband.py
+++ b/tests/test_schematics_si220_cband.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_all_ports_match_gds,
     check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
@@ -22,6 +23,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_all_ports_match_gds() -> None:
+    """Every declared schematic port side matches the GDS port orientation."""
+    check_all_ports_match_gds(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_si220_oband.py
+++ b/tests/test_schematics_si220_oband.py
@@ -6,6 +6,7 @@ import pytest
 from _schematic_checks import (
     check_all_ports_match_gds,
     check_bend_ports_left_top,
+    check_ports_clockwise_from_left,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_sax_port_order_matches_sdict,
@@ -28,6 +29,11 @@ def test_symbol_present() -> None:
 def test_all_ports_match_gds() -> None:
     """Every declared schematic port side matches the GDS port orientation."""
     check_all_ports_match_gds(PDK)
+
+
+def test_ports_clockwise_from_left() -> None:
+    """Schematic ports are listed clockwise-from-left within each side."""
+    check_ports_clockwise_from_left(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_si220_oband.py
+++ b/tests/test_schematics_si220_oband.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_all_ports_match_gds,
     check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
@@ -22,6 +23,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_all_ports_match_gds() -> None:
+    """Every declared schematic port side matches the GDS port orientation."""
+    check_all_ports_match_gds(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_si340.py
+++ b/tests/test_schematics_si340.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_all_ports_match_gds,
     check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
@@ -21,6 +22,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_all_ports_match_gds() -> None:
+    """Every declared schematic port side matches the GDS port orientation."""
+    check_all_ports_match_gds(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_si340.py
+++ b/tests/test_schematics_si340.py
@@ -6,6 +6,7 @@ import pytest
 from _schematic_checks import (
     check_all_ports_match_gds,
     check_bend_ports_left_top,
+    check_ports_clockwise_from_left,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_symbol_present,
@@ -27,6 +28,11 @@ def test_symbol_present() -> None:
 def test_all_ports_match_gds() -> None:
     """Every declared schematic port side matches the GDS port orientation."""
     check_all_ports_match_gds(PDK)
+
+
+def test_ports_clockwise_from_left() -> None:
+    """Schematic ports are listed clockwise-from-left within each side."""
+    check_ports_clockwise_from_left(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_si500.py
+++ b/tests/test_schematics_si500.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_all_ports_match_gds,
     check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
@@ -21,6 +22,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_all_ports_match_gds() -> None:
+    """Every declared schematic port side matches the GDS port orientation."""
+    check_all_ports_match_gds(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_si500.py
+++ b/tests/test_schematics_si500.py
@@ -6,6 +6,7 @@ import pytest
 from _schematic_checks import (
     check_all_ports_match_gds,
     check_bend_ports_left_top,
+    check_ports_clockwise_from_left,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_symbol_present,
@@ -27,6 +28,11 @@ def test_symbol_present() -> None:
 def test_all_ports_match_gds() -> None:
     """Every declared schematic port side matches the GDS port orientation."""
     check_all_ports_match_gds(PDK)
+
+
+def test_ports_clockwise_from_left() -> None:
+    """Schematic ports are listed clockwise-from-left within each side."""
+    check_ports_clockwise_from_left(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_si_sus.py
+++ b/tests/test_schematics_si_sus.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_all_ports_match_gds,
     check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
@@ -21,6 +22,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_all_ports_match_gds() -> None:
+    """Every declared schematic port side matches the GDS port orientation."""
+    check_all_ports_match_gds(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_si_sus.py
+++ b/tests/test_schematics_si_sus.py
@@ -6,6 +6,7 @@ import pytest
 from _schematic_checks import (
     check_all_ports_match_gds,
     check_bend_ports_left_top,
+    check_ports_clockwise_from_left,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_symbol_present,
@@ -27,6 +28,11 @@ def test_symbol_present() -> None:
 def test_all_ports_match_gds() -> None:
     """Every declared schematic port side matches the GDS port orientation."""
     check_all_ports_match_gds(PDK)
+
+
+def test_ports_clockwise_from_left() -> None:
+    """Schematic ports are listed clockwise-from-left within each side."""
+    check_ports_clockwise_from_left(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_sin200.py
+++ b/tests/test_schematics_sin200.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_all_ports_match_gds,
     check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
@@ -21,6 +22,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_all_ports_match_gds() -> None:
+    """Every declared schematic port side matches the GDS port orientation."""
+    check_all_ports_match_gds(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_sin200.py
+++ b/tests/test_schematics_sin200.py
@@ -6,6 +6,7 @@ import pytest
 from _schematic_checks import (
     check_all_ports_match_gds,
     check_bend_ports_left_top,
+    check_ports_clockwise_from_left,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_symbol_present,
@@ -27,6 +28,11 @@ def test_symbol_present() -> None:
 def test_all_ports_match_gds() -> None:
     """Every declared schematic port side matches the GDS port orientation."""
     check_all_ports_match_gds(PDK)
+
+
+def test_ports_clockwise_from_left() -> None:
+    """Schematic ports are listed clockwise-from-left within each side."""
+    check_ports_clockwise_from_left(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_sin300.py
+++ b/tests/test_schematics_sin300.py
@@ -6,6 +6,7 @@ import pytest
 from _schematic_checks import (
     check_all_ports_match_gds,
     check_bend_ports_left_top,
+    check_ports_clockwise_from_left,
     check_ports_subset_of_component,
     check_sax_model_refs,
     check_sax_port_order_matches_sdict,
@@ -28,6 +29,11 @@ def test_symbol_present() -> None:
 def test_all_ports_match_gds() -> None:
     """Every declared schematic port side matches the GDS port orientation."""
     check_all_ports_match_gds(PDK)
+
+
+def test_ports_clockwise_from_left() -> None:
+    """Schematic ports are listed clockwise-from-left within each side."""
+    check_ports_clockwise_from_left(PDK)
 
 
 def test_bend_ports_left_top() -> None:

--- a/tests/test_schematics_sin300.py
+++ b/tests/test_schematics_sin300.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 from _schematic_checks import (
+    check_all_ports_match_gds,
     check_bend_ports_left_top,
     check_ports_subset_of_component,
     check_sax_model_refs,
@@ -22,6 +23,11 @@ def _activate_pdk() -> None:
 def test_symbol_present() -> None:
     """Every schematic-driven cell exposes a non-empty symbol."""
     check_symbol_present(PDK)
+
+
+def test_all_ports_match_gds() -> None:
+    """Every declared schematic port side matches the GDS port orientation."""
+    check_all_ports_match_gds(PDK)
 
 
 def test_bend_ports_left_top() -> None:


### PR DESCRIPTION
## Summary
Follow-up to the bend left→top fix (#296). Audited every schematic-driven cell across all 8 sub-PDKs, comparing each declared port `side` to the real GDS port `orientation`, and fixed the mismatches so schematic symbols are not "twisted" relative to the layout.

## Fixes (declared side → matches GDS)
- **`_WIRE_BEND`**: `e2` bottom → **top** — fixes `wire_corner`, `wire_corner45`, `bend_metal` (the electrical analog of the bend bug). `wire_corner45_straight` switched from `_WIRE_STRAIGHT` to `_WIRE_BEND` (its `e2` is at 90°).
- **`_CROSSING`**: un-swap `o2`/`o4` → `o2` top, `o4` bottom (was a topological twist).
- **`_GRATING`**: `o2` top → **right** (matches GDS 0° and the Mosaic grating fan glyph).
- **`_RING_DOUBLE`** (new): `ring_double` now uses `[o1 L, o2 R, o3 L, o4 R]` — two parallel buses, instead of `_2X2` which twisted them.
- **`_RING_COUPLER`** (new): `coupler_ring` → `[o1 L, o2 T, o3 T, o4 R]` to match GDS (renders as a generic box).
- **`_HEATER_FULL`**: `l_e3` → right, `r_e1` → left to match GDS.
- **Heater symbol** `"modulator"` → generic model-driven **`"ckt"`** box so all heater ports render. (The `modulator` symbol uses hardcoded conn and cannot represent a multi-port heater — model-driven-modulator redesign tracked in doplaydo/gdsfactoryplus#3050.)

## Test
New `check_all_ports_match_gds` generalizes `check_bend_ports_left_top`: every declared port side must equal the real GDS orientation (left=180°, right=0°, top=90°, bottom=270°). Wired into all 8 per-band schematic test suites. One documented exemption: `spiral.o1` (both GDS ports at 0°, but it has a bespoke left→right glyph — would need a glyph redraw, not a preset tweak).

## Verification
- 43/43 schematic tests pass; ruff check + format clean.
- Confirmed the new check actually verifies all cells including composites (`ring_double`, `coupler_ring`) — nothing silently skipped — and a negative test (injecting a twisted declaration) is caught.

## Summary by Sourcery

Ensure schematic port orientations and ordering consistently match GDS layouts across PDKs and tighten schematic-driven validation.

Bug Fixes:
- Align schematic port sides for crossings, gratings, bends, ring elements, and heaters with their corresponding GDS port orientations to avoid twisted symbols.
- Switch wire corner and heater schematics to use corrected port presets so rendered symbols reflect the true layout connectivity.

Enhancements:
- Introduce shared checks that verify every schematic port side matches the GDS port orientation and that ports on each side are listed clockwise-from-left, with documented exemptions.
- Define dedicated ring-double and ring-coupler schematic port presets that reflect their physical bus and ring connectivity more accurately.
- Render heater schematics using a generic model-driven box symbol so all electrical ports are visible despite limitations of the modulator symbol.

Tests:
- Add per-PDK schematic tests invoking the new orientation and clockwise-order checks for all schematic-driven cells.