### PR TITLE
fix: correct pre-commit instructions and add tests section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,18 @@ uv sync --extra docs --extra dev
 
 ## Pre-commit
 
+Pre-commit hooks are centrally maintained in [pdk-ci-workflow](https://github.com/doplaydo/pdk-ci-workflow). `make dev` fetches the canonical config and installs the git hook.
+
 ```bash
-make pre-commit
+make dev
+```
+
+## Tests
+
+Run the test suite:
+
+```bash
+make test
 ```
 
 ## Release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # CORNERSTONE PDK 1.4.4
 
+The University of Southampton's CORNERSTONE silicon photonics platform, a 220nm SOI multi-project-wafer process built for accessible, low-cost prototyping.
+
 <!-- BADGES:START -->
 [![Docs](https://github.com/gdsfactory/cspdk/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/cspdk/actions/workflows/pages.yml)
 [![Tests](https://github.com/gdsfactory/cspdk/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/cspdk/actions/workflows/test_code.yml)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ uv sync --extra docs --extra dev
 
 ## Pre-commit
 
-Pre-commit hooks are centrally maintained in [pdk-ci-workflow](https://github.com/doplaydo/pdk-ci-workflow). `make dev` fetches the canonical config and installs the git hook.
+Pre-commit hooks are centrally maintained in [pdk-ci-workflow-public](https://github.com/doplaydo/pdk-ci-workflow-public). `make dev` fetches the canonical config and installs the git hook.
 
 ```bash
 make dev


### PR DESCRIPTION
The Makefile's pre-commit setup target is `dev` (fetches the canonical config from pdk-ci-workflow), not `make pre-commit`. This updates the README to match, and adds a missing `## Tests` section documenting `make test`.

Part of doplaydo/pdks#49.

## Summary by Sourcery

Clarify README instructions for running pre-commit setup and document how to run the test suite.

Documentation:
- Update pre-commit section in README to reference the centrally maintained hooks and the correct `make dev` setup command.
- Add a README tests section describing how to run the test suite with `make test`.