### PR TITLE
test: check all ports have manhattan orientations

### DIFF
--- a/tests/test_ge_on_si.py
+++ b/tests/test_ge_on_si.py
@@ -168,6 +168,28 @@ def test_optical_port_positions(component_name: str) -> None:
                 )
 
 
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )
+
+
 if __name__ == "__main__":
     component_type = "mzi_no"
     c = cells[component_type]()

--- a/tests/test_si220_cband.py
+++ b/tests/test_si220_cband.py
@@ -234,6 +234,28 @@ def test_optical_port_positions(component_name: str) -> None:
                 )
 
 
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )
+
+
 if __name__ == "__main__":
     component_type = "coupler_symmetric"
     c = cells[component_type]()

--- a/tests/test_si220_oband.py
+++ b/tests/test_si220_oband.py
@@ -230,6 +230,28 @@ def test_optical_port_positions(component_name: str) -> None:
                 )
 
 
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )
+
+
 if __name__ == "__main__":
     component_type = "coupler_symmetric"
     c = cells[component_type]()

--- a/tests/test_si340.py
+++ b/tests/test_si340.py
@@ -166,6 +166,28 @@ def test_optical_port_positions(component_name: str) -> None:
                 )
 
 
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )
+
+
 if __name__ == "__main__":
     component_type = "mzi_no"
     c = cells[component_type]()

--- a/tests/test_si500.py
+++ b/tests/test_si500.py
@@ -165,3 +165,25 @@ def test_optical_port_positions(component_name: str) -> None:
                 raise AssertionError(
                     f"Port {port.name} has width {port_width}, but the optical edge length is {edge_length}."
                 )
+
+
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )

--- a/tests/test_si_sus.py
+++ b/tests/test_si_sus.py
@@ -182,6 +182,28 @@ def test_optical_port_positions(component_name: str) -> None:
                 )
 
 
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )
+
+
 if __name__ == "__main__":
     component_type = "mzi_no"
     c = cells[component_type]()

--- a/tests/test_sin200.py
+++ b/tests/test_sin200.py
@@ -168,6 +168,28 @@ def test_optical_port_positions(component_name: str) -> None:
                 )
 
 
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )
+
+
 if __name__ == "__main__":
     component_type = "mzi_no"
     c = cells[component_type]()

--- a/tests/test_sin300.py
+++ b/tests/test_sin300.py
@@ -168,6 +168,28 @@ def test_optical_port_positions(component_name: str) -> None:
                 )
 
 
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )
+
+
 if __name__ == "__main__":
     component_type = "mzi_no"
     c = cells[component_type]()


### PR DESCRIPTION
Closes #331

Adds `test_port_orientations_manhattan` to all eight band test files (ge_on_si, si220 cband, si220 oband, si340, si500, si_sus, sin200, sin300). The test is parametrized over every PDK cell already covered by the band's `cell_names`, builds each cell, skips `gf.ComponentAllAngle` components, and asserts that every remaining port's orientation is 0, 90, 180 or 270 degrees (mod 360, `atol=1e-3`). A per-file `skip_test_manhattan_ports` set is provided (empty) so known issues can be quarantined explicitly rather than by weakening the check.

This is a templated rollout of the same test we are adding across our PDKs; the reference change was reviewed and approved by @joamatab.

⚠️ AI-created PR: a human must review the actual code changes before merge.

## Test plan

- [ ] CI passes (`test_port_orientations_manhattan` green across all eight bands)

## Summary by Sourcery

Add regression tests to ensure all non-all-angle PDK cell ports use manhattan orientations across all bands.

Tests:
- Add parametrized manhattan-orientation port test to ge_on_si, si220 cband/oband, si340, si500, si_sus, sin200, and sin300 band test suites.
- Introduce per-file skip list hooks to selectively disable the manhattan port orientation test for specific components if needed.