### PR TITLE
ci: add Generate nyanlib workflow and sync centralized templates

### DIFF
--- a/.github/workflows/gds-xor.yml
+++ b/.github/workflows/gds-xor.yml
@@ -1,0 +1,12 @@
+name: GDS XOR
+on:
+  pull_request:
+    paths:
+      - "**.gds"
+
+jobs:
+  gds-xor:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/gds-xor.yml@main

--- a/.github/workflows/generate_nyanlib.yml
+++ b/.github/workflows/generate_nyanlib.yml
@@ -1,0 +1,11 @@
+name: Generate nyanlib
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  generate:
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/generate_nyanlib.yml@main
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}


### PR DESCRIPTION
Adds `.github/workflows/generate_nyanlib.yml` (thin wrapper around the centralized reusable workflow) so `models.nyanlib` and SVG symbols are regenerated for this repo.

`check-template-drift` brought the rest of the centralized workflow files back in line at the same time:

- added `.github/workflows/gds-xor.yml`
- added `.github/workflows/generate_nyanlib.yml`

`pre-commit run --all-files` is green.

Closes #335

## Summary by Sourcery

Add and synchronize centralized workflows for asset generation and GDS validation.

CI:
- Add repository workflows for generating nyanlib assets on main pushes or manual runs and for checking GDS changes in pull requests.

Chores:
- Synchronize centralized CI workflow templates with the repository.