### PR TITLE
ci: sync workflow files with upstream templates

### DIFF
--- a/.github/workflows/generate_nyanlib.yml
+++ b/.github/workflows/generate_nyanlib.yml
@@ -4,10 +4,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   generate:
     uses: doplaydo/pdk-ci-workflow-public/.github/workflows/generate_nyanlib.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
-      GFP_GHCR_APP_ID: ${{ secrets.GFP_GHCR_APP_ID }}
-      GFP_GHCR_APP_PRIVATE_KEY: ${{ secrets.GFP_GHCR_APP_PRIVATE_KEY }}
+      GFP_ECR_IMAGE: ${{ secrets.GFP_ECR_IMAGE }}
+      SHARED_SERVICES_AWS_OIDC_ROLE_ARN: ${{ secrets.SHARED_SERVICES_AWS_OIDC_ROLE_ARN }}


### PR DESCRIPTION
All changes applied by `pre-commit run --all-files` with no manual edits (2 passes; pass 2 is fully green).

Closes #348.

Only `.github/workflows/generate_nyanlib.yml` changed — it picks up the upstream move from a GHCR GitHub App to ECR via AWS OIDC (new `permissions:` block incl. `id-token: write`, and `GFP_ECR_IMAGE` / `SHARED_SERVICES_AWS_OIDC_ROLE_ARN` in place of the two `GFP_GHCR_APP_*` secrets).

> **Before merging:** the two new secrets must be available to this repo, or the `generate_nyanlib` workflow will break. See the linked issue.

Opened by an AI agent — a human still needs to review the actual diff before merge.

## Test plan
- [ ] CI pre-commit job passes

## Summary by Sourcery

Synchronize the nyanlib generation workflow with the upstream template and migrate its container authentication from GHCR to AWS ECR.

Enhancements:
- Update the nyanlib generation workflow to authenticate with AWS ECR through GitHub OIDC instead of the previous GHCR application credentials.

CI:
- Grant the workflow the repository, pull-request, and OIDC permissions required by the updated reusable workflow.