### PR TITLE
feat(schematic): annotate die_with_pads as a type:die component

### DIFF
--- a/cspdk/_schematic.py
+++ b/cspdk/_schematic.py
@@ -23,6 +23,8 @@ into the SAX call; the link here targets the dispatcher name.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from kfactory.schematic import DSchematic
 
 # ---------------------------------------------------------------------------
@@ -146,6 +148,48 @@ _HEATER_FULL = [
 ]
 
 
+def _die_ports(
+    ngratings: int = 14,
+    npads: int = 31,
+    with_loopback: bool = True,
+    grating_coupler: object = "grating_coupler_rectangular",
+    **_ignored: object,
+) -> list[dict]:
+    """Symbol ports for ``die_with_pads``, derived from its kwargs.
+
+    Side is the die edge each port sits on — opposite of the GDS orientation,
+    which points into the die. Within each side the order follows the
+    nyanlib->Mosaic bridge convention (left bottom->top, right top->bottom,
+    top left->right, bottom right->left) so symbol labels match the layout.
+
+    The loopback absorbs the two edge gratings, so ngratings-2 ports are
+    exposed per W/E edge when ``with_loopback`` is set; ``npads`` pads per
+    N/S edge.
+    """
+    ports: list[dict] = []
+    if grating_coupler:
+        n = ngratings - 2 if with_loopback else ngratings
+        if n > 0:
+            # o1..o(n) right edge bottom->top, o(n+1)..o(2n) left edge top->bottom
+            ports += [
+                {"name": f"o{i}", "side": "right", "type": "photonic"}
+                for i in range(n, 0, -1)
+            ]
+            ports += [
+                {"name": f"o{i}", "side": "left", "type": "photonic"}
+                for i in range(2 * n, n, -1)
+            ]
+    ports += [
+        {"name": f"e{i}", "side": "bottom", "type": "electric"}
+        for i in range(npads, 0, -1)
+    ]
+    ports += [
+        {"name": f"e{i}", "side": "top", "type": "electric"}
+        for i in range(2 * npads, npads, -1)
+    ]
+    return ports
+
+
 # ---------------------------------------------------------------------------
 # Schematic builder
 # ---------------------------------------------------------------------------
@@ -213,13 +257,18 @@ def _make_schematic(
 def schematic(
     symbol: str,
     tags: list[str],
-    ports: list[dict],
+    ports: list[dict] | Callable[..., list[dict]],
     models: list[dict] | None = None,
 ):
-    """Return a ``schematic_function`` closure for use with ``@gf.cell``."""
+    """Return a ``schematic_function`` closure for use with ``@gf.cell``.
+
+    ``ports`` may be a static list or a callable receiving the component's
+    kwargs, for parameter-dependent port sets.
+    """
 
     def _schematic_fn(**kwargs) -> DSchematic:
-        return _make_schematic(symbol, tags, ports, models)
+        resolved_ports = ports(**kwargs) if callable(ports) else ports
+        return _make_schematic(symbol, tags, resolved_ports, models)
 
     return _schematic_fn
 

--- a/cspdk/si220/cband/_schematic.py
+++ b/cspdk/si220/cband/_schematic.py
@@ -15,6 +15,7 @@ from cspdk._schematic import (
     _RING_DOUBLE,
     _WIRE_BEND,
     _WIRE_STRAIGHT,
+    _die_ports,
     sax_model,
     schematic,
 )
@@ -184,3 +185,8 @@ crossing_rib_schematic = schematic(
 # Pads / via stacks
 pad_schematic = schematic("pad", ["pad"], _PAD)
 via_stack_schematic = schematic("pad", ["via", "stack"], _PAD)
+
+# Die: symbol "die" makes editors render it as a die (no background box).
+# Ports are derived from the factory kwargs; each side is the die edge the
+# port sits on — opposite of the inward-pointing GDS orientation.
+die_schematic = schematic("die", ["die"], _die_ports)

--- a/cspdk/si220/cband/cells/die_with_pads.py
+++ b/cspdk/si220/cband/cells/die_with_pads.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import (
     Size,
 )
 
-from cspdk.si220.cband._schematic import pad_schematic
+from cspdk.si220.cband._schematic import die_schematic, pad_schematic
 from cspdk.si220.cband.tech import LAYER
 
 
@@ -104,7 +104,7 @@ def die(size: tuple[float, float] = (16000.0, 1 * 3000.0)) -> gf.Component:
     return c
 
 
-@gf.cell(tags=["die"])
+@gf.cell(tags=["die"], schematic_function=die_schematic)
 def die_with_pads(
     size: tuple[float, float] = (11470.0, 4900.0),
     ngratings: int = 14,

--- a/cspdk/si220/oband/_schematic.py
+++ b/cspdk/si220/oband/_schematic.py
@@ -15,6 +15,7 @@ from cspdk._schematic import (
     _RING_DOUBLE,
     _WIRE_BEND,
     _WIRE_STRAIGHT,
+    _die_ports,
     sax_model,
     schematic,
 )
@@ -171,3 +172,8 @@ crossing_rib_schematic = schematic("crossing", ["crossing", "rib"], _CROSSING)
 # Pads / via stacks
 pad_schematic = schematic("pad", ["pad"], _PAD)
 via_stack_schematic = schematic("pad", ["via", "stack"], _PAD)
+
+# Die: symbol "die" makes editors render it as a die (no background box).
+# Ports are derived from the factory kwargs; each side is the die edge the
+# port sits on — opposite of the inward-pointing GDS orientation.
+die_schematic = schematic("die", ["die"], _die_ports)

--- a/cspdk/si220/oband/cells/die_with_pads.py
+++ b/cspdk/si220/oband/cells/die_with_pads.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import (
     Size,
 )
 
-from cspdk.si220.oband._schematic import pad_schematic
+from cspdk.si220.oband._schematic import die_schematic, pad_schematic
 from cspdk.si220.oband.tech import LAYER
 
 
@@ -119,7 +119,7 @@ def die(size: tuple[float, float] = (16000.0, 1 * 3000.0)) -> gf.Component:
     return c
 
 
-@gf.cell(tags=["die"])
+@gf.cell(tags=["die"], schematic_function=die_schematic)
 def die_with_pads(
     size: tuple[float, float] = (11470.0, 4900.0),
     ngratings: int = 14,


### PR DESCRIPTION
## What

`die_with_pads` in `si220/cband` and `si220/oband` now carries a schematic annotation with `symbol: "die"`, so editors render it as a die component (no background box, port labels outside the symbol) instead of a generic circuit box.

- **Ports are derived from the factory kwargs** — `ngratings`, `npads`, `with_loopback`, `grating_coupler` — through a new callable-ports option on the shared `schematic()` helper, instead of a static default-parameter snapshot. When GFP resolves schematic metadata per parameterization (dynamic-port support, doplaydo/gdsfactoryplus#3886), this annotation is already parameter-true.
- **Side semantics:** the declared side is the die edge the port sits on — the opposite of the port's GDS orientation, which points into the die. Within each side ports are ordered **clockwise** (left bottom→top, top left→right, right top→bottom, bottom right→left), matching the nyanlib→Mosaic bridge convention (which reverses left/bottom on the way into Mosaic).
- The edge loopback absorbs the two end gratings, so `ngratings-2` ports are exposed per W/E edge when `with_loopback` is set; `npads` pads per N/S edge. `grating_coupler=None` drops the photonic ports entirely.

## Dependency

Requires doplaydo/gdsfactoryplus#4402 for `type: "die"` rendering support in Mosaic/nyanlib.

## Verification

Annotation output was compared against built cells in both bands — names, sides, and per-side clockwise order match exactly:

| parameters | built ports | annotated |
| --- | --- | --- |
| defaults (worker path, no kwargs) | 86 | 86 ✓ |
| `ngratings=10, npads=5` | 26 | 26 |
| `ngratings=5, npads=3, with_loopback=False` | 16 | 16 |
| `grating_coupler=None` | 8 | 8 |
| oband `ngratings=12, npads=7` | 34 | 34 |

## Summary by Sourcery

Render parameterized SI220 `die_with_pads` components as die symbols with ports that accurately reflect their configured pads, gratings, and loopback connections.

New Features:
- Annotate `die_with_pads` components in both SI220 bands with die-specific schematic symbols and parameter-dependent photonic and electrical ports.

Enhancements:
- Add callable port definitions to the shared schematic helper, allowing schematic metadata to reflect component parameterizations and die-edge port ordering.